### PR TITLE
Exclude python `venv` and php `vendor` folders to speedup startup

### DIFF
--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -40,6 +40,8 @@ class Settings {
 	};
 	#excludeFolders = [
 		"**/node_modules/**",
+		"**/vendor/**",
+		"**/venv/**",
 		"**/.git/**",
 		"**/.vscode/**",
 		"**/.idea/**",


### PR DESCRIPTION
Fixed serious startup lag when I opened PHP Laravel or Python venv projects.