### PR TITLE
Add monochrome icon

### DIFF
--- a/res/android/mipmap-anydpi-v26/ic_launcher.xml
+++ b/res/android/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/res/android/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/res/android/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
Added monochrome icon for Android 13 "Themed icons" support.
![image](https://github.com/user-attachments/assets/6875c958-fd49-472a-8805-3db3693f97ea)
