### PR TITLE
updated install state to reflect fs behaviour of android

### DIFF
--- a/src/lib/installState.js
+++ b/src/lib/installState.js
@@ -29,6 +29,13 @@ export default class InstallState {
 				state.store = JSON.parse(
 					await fsOperation(state.storeUrl).readFile("utf-8"),
 				);
+
+				const patchedStore = {};
+				for (const [key, value] of Object.entries(state.store)) {
+					patchedStore[key.toLowerCase()] = value;
+				}
+
+				state.store = patchedStore;
 			} else {
 				state.store = {};
 				await fsOperation(INSTALL_STATE_STORAGE).createFile(state.id);
@@ -48,6 +55,7 @@ export default class InstallState {
 	 * @returns
 	 */
 	async isUpdated(url, content) {
+		url = url.toLowerCase();
 		const current = this.store[url];
 		const update =
 			typeof content === "string"
@@ -62,8 +70,13 @@ export default class InstallState {
 		}
 	}
 
+	/**
+	 *
+	 * @param {string} url
+	 * @returns
+	 */
 	exists(url) {
-		if (typeof this.store[url] !== "undefined") {
+		if (typeof this.store[url.toLowerCase()] !== "undefined") {
 			return true;
 		} else {
 			return false;
@@ -78,6 +91,7 @@ export default class InstallState {
 	}
 
 	async delete(url) {
+		url = url.toLowerCase();
 		if (await fsOperation(url).exists()) {
 			await fsOperation(url).delete();
 		}


### PR DESCRIPTION
I ran into an issues while updating a plugin.
The previous install had `readme.md` among its file while the update had `README.md` among its file. The `README.md` file was deleted becaused android sees the two file to be the same but InstallState sees them as different