### PR TITLE
fix: corrected typo in "vission" to "vision"

### DIFF
--- a/.github/ISSUE_TEMPLATE/0_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/0_bug_report.yml
@@ -25,7 +25,7 @@ body:
       required: true
   - type: textarea
     attributes:
-      label: If applicable, add mockups / screenshots regarding your vission
+      label: If applicable, add mockups / screenshots regarding your vision
       description: Drag issues into the text input below
     validations:
       required: false


### PR DESCRIPTION
Resolved a typographical error where "vission" was incorrectly spelled. Updated it to "vision".