### PR TITLE
Switch syntax for testing file presence

### DIFF
--- a/src/fileSystem/sftp.js
+++ b/src/fileSystem/sftp.js
@@ -124,7 +124,7 @@ class SftpClient {
 					}
 
 					const file = this.#safeName(filename);
-					const cmd = `[[ -f "${file}" ]] && echo "Already exists" || touch "${filename}"`;
+					const cmd = `[ -f "${file}" ] && echo "Already exists" || touch "${filename}"`;
 					sftp.exec(
 						cmd,
 						async (res) => {


### PR DESCRIPTION
[[ ]] is a bashism, adopted by some other shells (zsh, ksh) but not all. It does provide extra features (pattern matching and regex).

The POSIX way would be to use `test` or it's synonym ` [  ] `.  Both forms are equivalent, and the square brackets version [ ] requires spaces around the brackets as well as around each operator and operand. Here are some examples:

 ‐ `if [ -f "file.txt" ]; then echo "File exists"; fi`
 - `if test -f "file.txt"; then echo "File exists"; fi`

The POSIX standard does not include the double brackets [[ ]], so for scripts that need to be portable across different POSIX-compliant shells, we should stick with [ ] or test.