### PR TITLE
fix(browser): re-show console on page reload

### DIFF
--- a/src/plugins/browser/android/com/foxdebug/browser/Browser.java
+++ b/src/plugins/browser/android/com/foxdebug/browser/Browser.java
@@ -632,6 +632,12 @@ class BrowserWebViewClient extends WebViewClient {
         public void onReceiveValue(String value) {
           boolean show = !value.equals("null");
           browser.menu.setVisible("Console", show && !browser.emulator);
+
+          // If user had toggled "Console" on before, re-show it
+          if (browser.console && show) {
+            browser.setConsoleVisible(true);
+            browser.menu.setChecked("Console", true);
+          }
         }
       }
     );


### PR DESCRIPTION
Fixes 2nd issue of #919 

- check and automatically re-inject/show the console if previously toggled.