### PR TITLE
fix. launchApp function

### DIFF
--- a/src/plugins/system/android/com/foxdebug/system/System.java
+++ b/src/plugins/system/android/com/foxdebug/system/System.java
@@ -5,12 +5,10 @@ import android.app.PendingIntent;
 import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.ShortcutInfo;
-import android.content.pm.ShortcutManager;
 import android.content.res.Configuration;
+import android.content.*;
+import android.content.pm.*;
+import java.util.*;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.ImageDecoder;
@@ -582,21 +580,42 @@ public class System extends CordovaPlugin {
 
   private void launchApp(
     String appId,
-    String action,
-    String value,
+    String className,
+    String data,
     CallbackContext callback
-  ) {
-    Intent intent = context
-      .getPackageManager()
-      .getLaunchIntentForPackage(appId);
-    if (intent == null) {
-      callback.error("App not found");
+) {
+    if (appId == null || appId.equals("")) {
+      callback.error("No package name provided.");
       return;
     }
-    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-    context.startActivity(intent);
-    callback.success("Launched " + appId);
-  }
+
+    if (className == null || className.equals("")) {
+      callback.error("No activity class name provided.");
+      return;
+    }
+
+    try{
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+        intent.addCategory(Intent.CATEGORY_LAUNCHER);
+        intent.setPackage(appId);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+
+        if (data != null && !data.equals("")) {
+          intent.putExtra("acode_data", data);
+        }
+       
+        intent.setClassName(appId, className);
+        activity.startActivity(intent);
+        callback.success("Launched " + appId);
+    }catch(Exception e){
+      callback.error(e.toString());
+      return;
+    }
+
+
+    
+}
+
 
   private void addShortcut(
     String id,

--- a/src/plugins/system/system.d.ts
+++ b/src/plugins/system/system.d.ts
@@ -197,8 +197,8 @@ interface System {
    */
   launchApp(
     app: string,
-    action: string,
-    value: string,
+    className: string,
+    data: string,
     onSuccess: OnSuccessBool,
     onFail: OnFail,
   ): void;

--- a/src/plugins/system/system.d.ts
+++ b/src/plugins/system/system.d.ts
@@ -189,9 +189,9 @@ interface System {
   openInBrowser(src: string): void;
   /**
    * Launches and app
-   * @param app
-   * @param action
-   * @param value
+   * @param app the package name of the app
+   * @param className the full class name of the activity
+   * @param data Data to pass to the app
    * @param onSuccess
    * @param onFail
    */

--- a/src/plugins/system/www/plugin.js
+++ b/src/plugins/system/www/plugin.js
@@ -65,8 +65,8 @@ module.exports = {
   openInBrowser: function (src) {
     cordova.exec(null, null, 'System', 'open-in-browser', [src]);
   },
-  launchApp: function (app, action, value, onSuccess, onFail) {
-    cordova.exec(onSuccess, onFail, 'System', 'launch-app', [app, action, value]);
+  launchApp: function (app, className, data, onSuccess, onFail) {
+    cordova.exec(onSuccess, onFail, 'System', 'launch-app', [app, className, data]);
   },
   inAppBrowser: function (url, title, showButtons, disableCache) {
     var myInAppBrowser = {

--- a/www/index.html
+++ b/www/index.html
@@ -165,17 +165,17 @@
 
     <title>Acode</title>
       <!--styles-->
-<link rel="stylesheet" href="./css/build/218.css">
-<link rel="stylesheet" href="./css/build/32.css">
-<link rel="stylesheet" href="./css/build/383.css">
-<link rel="stylesheet" href="./css/build/53.css">
-<link rel="stylesheet" href="./css/build/609.css">
 <link rel="stylesheet" href="./css/build/about.css">
 <link rel="stylesheet" href="./css/build/customTheme.css">
 <link rel="stylesheet" href="./css/build/donate.css">
 <link rel="stylesheet" href="./css/build/fileBrowser.css">
 <link rel="stylesheet" href="./css/build/main.css">
 <link rel="stylesheet" href="./css/build/plugins.css">
+<link rel="stylesheet" href="./css/build/src_pages_quickTools_quickTools_js.css">
+<link rel="stylesheet" href="./css/build/src_sidebarApps_extensions_index_js.css">
+<link rel="stylesheet" href="./css/build/src_sidebarApps_files_index_js.css">
+<link rel="stylesheet" href="./css/build/src_sidebarApps_notification_index_js.css">
+<link rel="stylesheet" href="./css/build/src_sidebarApps_searchInFiles_index_js.css">
 <link rel="stylesheet" href="./css/build/themeSetting.css">
 <!--styles_end-->
 </head>


### PR DESCRIPTION
The previously used method of launching apps via getLaunchIntentForPackage() is very limited and often doesn't work due to privacy restrictions in Android 11 and above. This PR fixes the issue by explicitly providing the activity class name to the intent. It also sends a string extra if provided. The target app should be aware of this, allowing plugins to send data to supported apps.

this is the new signature

```typescript

/**
   * Launches and app
   * @param app the package name of the app
   * @param className the full class name of the activity
   * @param data Data to pass to the app
   * @param onSuccess
   * @param onFail
   */
  launchApp(
    app: string,
    className: string,
    data: string,
    onSuccess: OnSuccessBool,
    onFail: OnFail,
  ): void;


```

Example Uses:

```javascript

system.launchApp(
  "com.example.targetapp",                 // app package name
  "com.example.targetapp.MainActivity",    // full activity class name
  "some string data to send",              // optional string data
  (success) => {
   console.log("App launched successfully!");
  },
  (error) => {
    console.error("Failed to launch app:", error);
  }
);


```