### PR TITLE
file: re-emit switch and load file events after plugin load

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -241,6 +241,15 @@ async function onDeviceReady() {
 			// load plugins
 			try {
 				await loadPlugins();
+
+				// Re-emit events for active file after plugins are loaded
+				const { activeFile } = editorManager;
+				if (activeFile?.uri) {
+					// Re-emit file-loaded event
+					editorManager.emit("file-loaded", activeFile);
+					// Re-emit switch-file event
+					editorManager.emit("switch-file", activeFile);
+				}
 			} catch (error) {
 				window.log("error", "Failed to load plugins!");
 				window.log("error", error);


### PR DESCRIPTION
re-emit 'switch-file' and 'file-loaded' event after loading plugins , as plugins are loaded after opening app and those events also gets triggered before loading plugins, so many plugins will face issues such as lsp plugins. For compatibility it will re-emit events .