### PR TITLE
Add Custom File Type Handler API

### DIFF
--- a/src/lib/acode.js
+++ b/src/lib/acode.js
@@ -23,6 +23,7 @@ import actionStack from "lib/actionStack";
 import commands from "lib/commands";
 import EditorFile from "lib/editorFile";
 import files from "lib/fileList";
+import fileTypeHandler from "lib/fileTypeHandler";
 import fonts from "lib/fonts";
 import NotificationManager from "lib/notificationManager";
 import openFolder from "lib/openFolder";
@@ -494,5 +495,24 @@ export default class Acode {
 			action,
 			type,
 		});
+	}
+
+	/**
+	 * Register a custom file type handler
+	 * @param {string} id Unique identifier for the handler
+	 * @param {Object} options Handler configuration
+	 * @param {string[]} options.extensions File extensions to handle (without dots)
+	 * @param {function} options.handleFile Function that handles the file opening
+	 */
+	registerFileHandler(id, options) {
+		fileTypeHandler.registerFileHandler(id, options);
+	}
+
+	/**
+	 * Unregister a file type handler
+	 * @param {string} id The handler id to remove
+	 */
+	unregisterFileHandler(id) {
+		fileTypeHandler.unregisterFileHandler(id);
 	}
 }

--- a/src/lib/fileTypeHandler.js
+++ b/src/lib/fileTypeHandler.js
@@ -1,0 +1,94 @@
+/**
+ * @typedef {Object} FileTypeHandler
+ * @property {string} id - Unique identifier for the handler
+ * @property {string[]} extensions - File extensions this handler supports (without dots)
+ * @property {function} handleFile - Function that handles the file
+ */
+
+/**
+ * @typedef {Object} FileInfo
+ * @property {string} name - File name
+ * @property {string} uri - File URI
+ * @property {Object} fs - File system operations object
+ * @property {Object} stats - File stats
+ * @property {boolean} readOnly - Whether the file is read-only
+ * @property {Object} options - Additional options passed during file open
+ */
+
+class FileTypeHandlerRegistry {
+	#handlers = new Map();
+
+	/**
+	 * Register a file type handler
+	 * @param {string} id - Unique identifier for the handler
+	 * @param {Object} options - Handler options
+	 * @param {string[]} options.extensions - File extensions to handle (without dots)
+	 * @param {function(FileInfo): Promise<void>} options.handleFile - Async function to handle the file
+	 * @throws {Error} If id is already registered or required options are missing
+	 */
+	registerFileHandler(id, { extensions, handleFile }) {
+		if (this.#handlers.has(id)) {
+			throw new Error(`Handler with id '${id}' is already registered`);
+		}
+
+		if (!extensions?.length) {
+			throw new Error("extensions array is required");
+		}
+
+		if (typeof handleFile !== "function") {
+			throw new Error("handleFile function is required");
+		}
+
+		// Normalize extensions (remove dots if present, convert to lowercase)
+		const normalizedExts = extensions.map((ext) =>
+			ext.toLowerCase().replace(/^\./, ""),
+		);
+
+		this.#handlers.set(id, {
+			extensions: normalizedExts,
+			handleFile,
+		});
+	}
+
+	/**
+	 * Unregister a file type handler
+	 * @param {string} id - The handler id to remove
+	 */
+	unregisterFileHandler(id) {
+		this.#handlers.delete(id);
+	}
+
+	/**
+	 * Get a file handler for a given filename
+	 * @param {string} filename
+	 * @returns {Object|null} The matching handler or null if none found
+	 */
+	getFileHandler(filename) {
+		const ext = filename.split(".").pop().toLowerCase();
+
+		for (const [id, handler] of this.#handlers) {
+			if (
+				handler.extensions.includes(ext) ||
+				handler.extensions.includes("*")
+			) {
+				return {
+					id,
+					...handler,
+				};
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get all registered handlers
+	 * @returns {Map} Map of all registered handlers
+	 */
+	getHandlers() {
+		return new Map(this.#handlers);
+	}
+}
+
+export const fileTypeHandler = new FileTypeHandlerRegistry();
+export default fileTypeHandler;

--- a/src/lib/fileTypeHandler.js
+++ b/src/lib/fileTypeHandler.js
@@ -9,7 +9,6 @@
  * @typedef {Object} FileInfo
  * @property {string} name - File name
  * @property {string} uri - File URI
- * @property {Object} fs - File system operations object
  * @property {Object} stats - File stats
  * @property {boolean} readOnly - Whether the file is read-only
  * @property {Object} options - Additional options passed during file open

--- a/www/index.html
+++ b/www/index.html
@@ -165,17 +165,17 @@
 
     <title>Acode</title>
       <!--styles-->
+<link rel="stylesheet" href="./css/build/218.css">
+<link rel="stylesheet" href="./css/build/32.css">
+<link rel="stylesheet" href="./css/build/383.css">
+<link rel="stylesheet" href="./css/build/53.css">
+<link rel="stylesheet" href="./css/build/609.css">
 <link rel="stylesheet" href="./css/build/about.css">
 <link rel="stylesheet" href="./css/build/customTheme.css">
 <link rel="stylesheet" href="./css/build/donate.css">
 <link rel="stylesheet" href="./css/build/fileBrowser.css">
 <link rel="stylesheet" href="./css/build/main.css">
 <link rel="stylesheet" href="./css/build/plugins.css">
-<link rel="stylesheet" href="./css/build/src_pages_quickTools_quickTools_js.css">
-<link rel="stylesheet" href="./css/build/src_sidebarApps_extensions_index_js.css">
-<link rel="stylesheet" href="./css/build/src_sidebarApps_files_index_js.css">
-<link rel="stylesheet" href="./css/build/src_sidebarApps_notification_index_js.css">
-<link rel="stylesheet" href="./css/build/src_sidebarApps_searchInFiles_index_js.css">
 <link rel="stylesheet" href="./css/build/themeSetting.css">
 <!--styles_end-->
 </head>


### PR DESCRIPTION
This PR introduces a file type handler system that allows plugins to register custom handlers for specific file types. This enables plugins to provide specialized viewers or editors for different file formats (e.g., PDF viewers, image editors, etc.).

## Key Features

- Plugins can register handlers for specific file extensions
- "Text Editor" always available as fallback option

## Example Usage

```js
acode.registerFileHandler({
  id: 'my-pdf-viewer-id',
  extensions: ['pdf'],
  async handleFile({ name, uri, fs, options }) {
    // Handler implementation
  }
});
