### PR TITLE
File Menu & QuickTools Visibility for editor tabs

### DIFF
--- a/src/handlers/quickTools.js
+++ b/src/handlers/quickTools.js
@@ -161,7 +161,11 @@ export default function actions(action, value) {
 			return true;
 
 		case "set-height":
-			setHeight(value);
+			if (typeof value === "object") {
+				setHeight(value.height, value.save);
+			} else {
+				setHeight(value);
+			}
 			return true;
 
 		case "search-prev":
@@ -275,12 +279,14 @@ function toggle() {
 	focusEditor();
 }
 
-function setHeight(height = 1) {
+function setHeight(height = 1, save = true) {
 	const { $footer, $row1, $row2 } = quickTools;
 	const { editor } = editorManager;
 
 	setFooterHeight(height);
-	appSettings.update({ quickTools: height }, false);
+	if (save) {
+		appSettings.update({ quickTools: height }, false);
+	}
 	editor.resize(true);
 
 	if (!height) {

--- a/src/lib/editorFile.js
+++ b/src/lib/editorFile.js
@@ -49,6 +49,11 @@ export default class EditorFile {
 	 * @type {HTMLElement}
 	 */
 	#content = null;
+	/**
+	 * Whether to hide quicktools for this tab
+	 * @type {boolean}
+	 */
+	hideQuickTools = false;
 
 	/**
 	 * Custom stylesheets for tab
@@ -185,6 +190,8 @@ export default class EditorFile {
 	constructor(filename, options) {
 		const { addFile, getFile } = editorManager;
 		let doesExists = null;
+
+		this.hideQuickTools = options?.hideQuickTools || false;
 
 		// if options are passed
 		if (options) {

--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -9,6 +9,7 @@ import ScrollBar from "components/scrollbar";
 import SideButton, { sideButtonContainer } from "components/sideButton";
 import keyboardHandler from "handlers/keyboard";
 import { keydownState } from "handlers/keyboard";
+import actions from "handlers/quickTools";
 import sidebarApps from "sidebarApps";
 import EditorFile from "./editorFile";
 import appSettings from "./settings";
@@ -644,6 +645,14 @@ async function EditorManager($header, $body) {
 		}
 
 		manager.activeFile = file;
+
+		if (file.hideQuickTools) {
+			root.classList.add("hide-floating-button");
+			actions("set-height", { height: 0, save: false });
+		} else {
+			root.classList.remove("hide-floating-button");
+			actions("set-height", appSettings.value.quickTools);
+		}
 
 		if (file.type === "editor") {
 			editor.setSession(file.session);

--- a/src/lib/loadPlugins.js
+++ b/src/lib/loadPlugins.js
@@ -21,6 +21,7 @@ const THEME_IDENTIFIERS = new Set([
 	"sweet",
 	"moonlight",
 	"bluloco",
+	"acode.plugin.extra_syntax_highlights",
 ]);
 
 export default async function loadPlugins(loadOnlyTheme = false) {

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -510,8 +510,15 @@ async function loadApp() {
 	function onEditorUpdate(mode, saveState = true) {
 		const { activeFile } = editorManager;
 
-		if (!$editMenuToggler.isConnected) {
-			$header.insertBefore($editMenuToggler, $header.lastChild);
+		// if (!$editMenuToggler.isConnected) {
+		// 	$header.insertBefore($editMenuToggler, $header.lastChild);
+		// }
+		if (activeFile?.type === "page") {
+			$editMenuToggler.remove();
+		} else {
+			if (!$editMenuToggler.isConnected) {
+				$header.insertBefore($editMenuToggler, $header.lastChild);
+			}
 		}
 
 		if (mode === "switch-file") {


### PR DESCRIPTION
## Changes
This PR implements visibility management for the file menu icon and adds QuickTools visibility control per tab.

### File Menu Icon (Pencil Icon)
- Hides the file menu icon from header when active editor tab type is "page", otherwise show it

### QuickTools
- Adds `hideQuickTools` boolean property to EditorFile (defaults to false)
- Allows per-tab control of QuickTools visibility

## Usage
```javascript
// Create a new tab with QuickTools hidden
new EditorFile("My Tab", {
  hideQuickTools: true
});
```