### PR TITLE
Fix html content access

### DIFF
--- a/src/lib/run.js
+++ b/src/lib/run.js
@@ -180,14 +180,14 @@ async function run(
 		const reqId = req.requestId;
 		let reqPath = req.path.substring(1);
 
-		console.log(`XREQPATH ${reqPath}`)
-		console.log(req)
+		console.log(`XREQPATH ${reqPath}`);
+		console.log(req);
 
 		if (!reqPath || (reqPath.endsWith("/") && reqPath.length === 1)) {
 			reqPath = getRelativePath();
 		}
 
-		console.log(`XREQPATH1 ${reqPath}`)
+		console.log(`XREQPATH1 ${reqPath}`);
 
 		const ext = Url.extname(reqPath);
 		let url = null;
@@ -263,38 +263,43 @@ async function run(
 				const projectFolder = addedFolder[0];
 				const query = url.split("?")[1];
 				let rootFolder = "";
-			  
-				if (projectFolder !== undefined && pathName.includes(projectFolder.url)) {
-				  rootFolder = projectFolder.url;
+
+				if (
+					projectFolder !== undefined &&
+					pathName.includes(projectFolder.url)
+				) {
+					rootFolder = projectFolder.url;
 				} else {
-				  rootFolder = pathName;
+					rootFolder = pathName;
 				}
-			  
-				if ((rootFolder.startsWith("ftp:") || rootFolder.startsWith("sftp:")) && rootFolder.includes("?")) {
-				  rootFolder = rootFolder.split("?")[0];
+
+				if (
+					(rootFolder.startsWith("ftp:") || rootFolder.startsWith("sftp:")) &&
+					rootFolder.includes("?")
+				) {
+					rootFolder = rootFolder.split("?")[0];
 				}
-			  
-				
+
 				rootFolder = rootFolder.replace(/\/+$/, ""); // remove trailing slash
-				reqPath = reqPath.replace(/^\/+/, "");       // remove leading slash
-			  
+				reqPath = reqPath.replace(/^\/+/, ""); // remove leading slash
+
 				const rootParts = rootFolder.split("/");
 				const pathParts = reqPath.split("/");
-			  
+
 				if (pathParts[0] === rootParts[rootParts.length - 1]) {
-				  pathParts.shift();
+					pathParts.shift();
 				}
-			  
+
 				const fullPath = Url.join(rootFolder, pathParts.join("/"));
-			  
+
 				// Add back the query if present
 				url = query ? `${fullPath}?${query}` : fullPath;
-			  
+
 				file = editorManager.getFile(url, "uri");
-			  } else if (!activeFile.uri) {
+			} else if (!activeFile.uri) {
 				file = activeFile;
-			  }
-			  
+			}
+
 			switch (ext) {
 				case ".htm":
 				case ".html":
@@ -557,8 +562,8 @@ async function run(
 		let rootFolder = pathName;
 		if (projectFolder !== undefined && pathName.includes(projectFolder)) {
 			rootFolder = projectFolder.url;
-		}else{
-			rootFolder = pathName
+		} else {
+			rootFolder = pathName;
 		}
 
 		//make the uri absolute if necessary

--- a/src/lib/run.js
+++ b/src/lib/run.js
@@ -180,9 +180,14 @@ async function run(
 		const reqId = req.requestId;
 		let reqPath = req.path.substring(1);
 
+		console.log(`XREQPATH ${reqPath}`)
+		console.log(req)
+
 		if (!reqPath || (reqPath.endsWith("/") && reqPath.length === 1)) {
 			reqPath = getRelativePath();
 		}
+
+		console.log(`XREQPATH1 ${reqPath}`)
 
 		const ext = Url.extname(reqPath);
 		let url = null;
@@ -256,37 +261,40 @@ async function run(
 
 			if (pathName) {
 				const projectFolder = addedFolder[0];
-
-				let rootFolder = "";
-				if (projectFolder !== undefined && pathName.includes(projectFolder)) {
-					rootFolder = projectFolder.url;
-				} else {
-					rootFolder = pathName;
-				}
-
 				const query = url.split("?")[1];
-
-				//remove the query string if present this is needs to be removed because the url is not valid
-				if (rootFolder.startsWith("ftp:") || rootFolder.startsWith("sftp:")) {
-					if (rootFolder.includes("?")) {
-						rootFolder = rootFolder.split("?")[0];
-					}
+				let rootFolder = "";
+			  
+				if (projectFolder !== undefined && pathName.includes(projectFolder.url)) {
+				  rootFolder = projectFolder.url;
+				} else {
+				  rootFolder = pathName;
 				}
-
-				url = Url.join(rootFolder, reqPath);
-
-				//attach the ftp query string to the url
-				if (query) {
-					url = `${url}?${query}`;
+			  
+				if ((rootFolder.startsWith("ftp:") || rootFolder.startsWith("sftp:")) && rootFolder.includes("?")) {
+				  rootFolder = rootFolder.split("?")[0];
 				}
-
-				console.log("url", url);
-
+			  
+				
+				rootFolder = rootFolder.replace(/\/+$/, ""); // remove trailing slash
+				reqPath = reqPath.replace(/^\/+/, "");       // remove leading slash
+			  
+				const rootParts = rootFolder.split("/");
+				const pathParts = reqPath.split("/");
+			  
+				if (pathParts[0] === rootParts[rootParts.length - 1]) {
+				  pathParts.shift();
+				}
+			  
+				const fullPath = Url.join(rootFolder, pathParts.join("/"));
+			  
+				// Add back the query if present
+				url = query ? `${fullPath}?${query}` : fullPath;
+			  
 				file = editorManager.getFile(url, "uri");
-			} else if (!activeFile.uri) {
+			  } else if (!activeFile.uri) {
 				file = activeFile;
-			}
-
+			  }
+			  
 			switch (ext) {
 				case ".htm":
 				case ".html":
@@ -547,16 +555,14 @@ async function run(
 
 		// Set the root folder to the file parent if no project folder is set
 		let rootFolder = pathName;
-		if (projectFolder !== undefined) {
+		if (projectFolder !== undefined && pathName.includes(projectFolder)) {
 			rootFolder = projectFolder.url;
+		}else{
+			rootFolder = pathName
 		}
 
 		//make the uri absolute if necessary
 		rootFolder = makeUriAbsoluteIfNeeded(rootFolder);
-
-		console.log("rootFolder", rootFolder);
-		console.log("pathName", pathName);
-		console.log("filename", filename);
 
 		// Parent of the file
 		let filePath = pathName;

--- a/src/lib/run.js
+++ b/src/lib/run.js
@@ -155,6 +155,7 @@ async function run(
 	}
 
 	function startServer() {
+		//isFallback = true;
 		webServer?.stop();
 		webServer = CreateServer(port, openBrowser, onError);
 		webServer.setOnRequestHandler(handleRequest);
@@ -253,14 +254,16 @@ async function run(
 
 			let file = activeFile.SAFMode === "single" ? activeFile : null;
 
-			if (pathName && isFallback) {
+			if (pathName) {
 				const projectFolder = addedFolder[0];
 
-				//set the root folder to the file parent if no project folder is set
-				let rootFolder = pathName;
-				if (projectFolder !== undefined) {
+				let rootFolder = "";
+				if (projectFolder !== undefined && pathName.includes(projectFolder)) {
 					rootFolder = projectFolder.url;
+				} else {
+					rootFolder = pathName;
 				}
+
 				const query = url.split("?")[1];
 
 				//remove the query string if present this is needs to be removed because the url is not valid


### PR DESCRIPTION
**Note:** If your HTML file is not inside an opened project folder, it can only access files in the same folder or below it  not outside.

### For example:

* Let's say your HTML file is at:
  `/sdcard/HelloWorld/html/index.html`

---

✅ **Case 1: You open `/sdcard/HelloWorld` as the project folder**

* Now the HTML file **can access**:

  * `/sdcard/HelloWorld/css/style.css`
  * `/sdcard/HelloWorld/images/logo.png`
  * `/sdcard/HelloWorld/html/scripts/app.js`

* But it **cannot access**:

  * `/sdcard/AnotherFolder/data.json`
    (because it's outside the project root)

---

❌ **Case 2: No folder is opened in the sidebar or a different folder is opened (just the HTML file)**

* Now the root becomes `/sdcard/HelloWorld/html`, so the HTML file **can only access**:

  * `/sdcard/HelloWorld/html/scripts/app.js`
  * `/sdcard/HelloWorld/html/images/logo.png`

* It **cannot access**:

  * `/sdcard/HelloWorld/css/style.css`
    (because it’s outside `/sdcard/HelloWorld/html`)