### PR TITLE
Fix renaming current Termux URI file whilst viewing/editing it

### DIFF
--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -353,7 +353,17 @@ export default {
 		if (uri) {
 			const fs = fsOperation(uri);
 			try {
-				const newUri = await fs.renameTo(newname);
+				let newUri;
+				if (uri.startsWith("content://com.termux.documents/tree/")) {
+					// Special handling for Termux content files
+					const newFilePath = Url.join(Url.dirname(url), newname);
+					const content = await fs.readFile();
+					await fsOperation(Url.dirname(url)).createFile(newname, content);
+					await fs.delete();
+					newUrl = newFilePath;
+				} else {
+					newUri = await fs.renameTo(newname);
+				}
 				const stat = await fsOperation(newUri).stat();
 
 				newname = stat.name;


### PR DESCRIPTION
Fixes: https://github.com/Acode-Foundation/Acode/issues/1009#issuecomment-2939504348

Changes based on https://github.com/Acode-Foundation/Acode/commit/9a825890ce98de8f5419f51d7bbf6f2e88994c30#diff-12ff7f0e737a86da8319460b3e8eefa377543bf78c753bf614ef826233d83476L414-R432