### PR TITLE
fix: don't save state of SAFMode="single" files

### DIFF
--- a/src/lib/saveState.js
+++ b/src/lib/saveState.js
@@ -13,6 +13,7 @@ export default () => {
 	files.forEach((file) => {
 		if (file.type !== "editor") return;
 		if (file.id === constants.DEFAULT_FILE_SESSION) return;
+		if (file.SAFMode === "single") return;
 
 		const fileJson = {
 			id: file.id,


### PR DESCRIPTION
Files opened with `SAFMode="single"` are accessed via a SAF intent, which provides only temporary access to their URIs. Saving the state for these files can cause issues on the next app startup, as the temporary access is revoked and the app will be unable to access the file again. This change prevents saving the state for such files, avoiding potential errors and other related issues.