### PR TITLE
fix: plugin passing undefined to plugin item on plugin page

### DIFF
--- a/src/pages/plugin/plugin.js
+++ b/src/pages/plugin/plugin.js
@@ -188,7 +188,7 @@ export default async function PluginInclude(
 				loadAd(this),
 				installPlugin(plugin.source || id, plugin.name, purchaseToken),
 			]);
-			if (onInstall) onInstall(plugin.id);
+			if (onInstall) onInstall(plugin);
 			installed = true;
 			update = false;
 			if (!plugin.price && IS_FREE_VERSION && (await window.iad?.isLoaded())) {


### PR DESCRIPTION
- Refactor onInstall to accept the full plugin object instead of just pluginId.
- Prevent duplicate entries in installed list and DOM.
- Fixes issues where plugins installed via search/filter/direct URL would not appear or just appending default in installed list until page reload.

---

![Screenshot_2025-06-25-13-23-28-780-edit_com foxdebug acodefree](https://github.com/user-attachments/assets/428b926f-367f-41b0-9eab-c9052ac67c72)
