### PR TITLE
fix: Make "None" option clickable in select dialog on formatter settings

### DIFF
--- a/src/dialogs/select.js
+++ b/src/dialogs/select.js
@@ -144,7 +144,7 @@ function select(title, items, options = {}) {
 					target = target.parentElement;
 				}
 
-				if (!itemOptions.value) return;
+				if (itemOptions.value === undefined) return;
 				if (hideOnSelect) hide();
 				res(itemOptions.value);
 			};

--- a/src/settings/formatterSettings.js
+++ b/src/settings/formatterSettings.js
@@ -33,7 +33,12 @@ export default function formatterSettings(languageName) {
 	page.show(languageName);
 
 	function callback(key, value) {
-		values.formatter[key] = value;
+		if (value === null) {
+			// Delete the key when "none" is selected
+			delete values.formatter[key];
+		} else {
+			values.formatter[key] = value;
+		}
 		appSettings.update();
 	}
 }


### PR DESCRIPTION
The "None" option in the select dialog was unclickable because the click handler was prematurely returning when the item's value was falsy. This affected options with a `null` value, such as the "None" option for formatters.

This commit modifies the click handler to allow `null` values to be selected. The handler now only returns early if the item's value is `undefined`.

Also when selected `None` on formatters settings then delete the key saved in settings for that language, as it is not require in case of `null`