### PR TITLE
Added Fdroid flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pnpm-lock.yaml
 .zed
 .idea
 ace-builds
+fdroid.bool

--- a/hooks/post-process.js
+++ b/hooks/post-process.js
@@ -30,6 +30,39 @@ deleteDirRecursively(resPath, [
 ]);
 copyDirRecursively(localResPath, resPath);
 enableLegacyJni()
+enableStaticContext()
+patchTargetSdkVersion()
+
+
+function patchTargetSdkVersion() {
+  const prefix = execSync('npm prefix').toString().trim();
+  const gradleFile = path.join(prefix, 'platforms/android/app/build.gradle');
+
+  if (!fs.existsSync(gradleFile)) {
+    console.warn('[Cordova Hook] ⚠️ build.gradle not found');
+    return;
+  }
+
+  let content = fs.readFileSync(gradleFile, 'utf-8');
+
+  const sdkRegex = /targetSdkVersion\s+(cordovaConfig\.SDK_VERSION|\d+)/;
+
+  if (sdkRegex.test(content)) {
+    const fdroid = fs.readFileSync(path.join(prefix,'fdroid.bool'), 'utf-8');
+    var api = "34"
+    if(fdroid === "true"){
+      api = "28"
+    }else{
+      
+    }
+
+    content = content.replace(sdkRegex, 'targetSdkVersion '+api);
+    fs.writeFileSync(gradleFile, content, 'utf-8');
+    console.log('[Cordova Hook] ✅ Patched targetSdkVersion to '+api);
+  } else {
+    console.warn('[Cordova Hook] ⚠️ targetSdkVersion not found');
+  }
+}
 
 
 function enableLegacyJni() {
@@ -58,6 +91,63 @@ function enableLegacyJni() {
   fs.writeFileSync(gradleFile, content, 'utf-8');
   console.log('[Cordova Hook] ✅ Enabled legacy JNI packaging');
 }
+
+function enableStaticContext() {
+  try {
+    const prefix = execSync('npm prefix').toString().trim();
+    const mainActivityPath = path.join(
+      prefix,
+      'platforms/android/app/src/main/java/com/foxdebug/acode/MainActivity.java'
+    );
+
+    if (!fs.existsSync(mainActivityPath)) {
+      return;
+    }
+
+    let content = fs.readFileSync(mainActivityPath, 'utf-8');
+
+    // Skip if fully patched
+    if (
+      content.includes('WeakReference<Context>') &&
+      content.includes('public static Context getContext()') &&
+      content.includes('weakContext = new WeakReference<>(this);')
+    ) {
+      return;
+    }
+
+    // Add missing imports
+    if (!content.includes('import java.lang.ref.WeakReference;')) {
+      content = content.replace(
+        /import org\.apache\.cordova\.\*;/,
+        match =>
+          match +
+          '\nimport android.content.Context;\nimport java.lang.ref.WeakReference;'
+      );
+    }
+
+    // Inject static field and method into class body
+    content = content.replace(
+      /public class MainActivity extends CordovaActivity\s*\{/,
+      match =>
+        match +
+        `\n\n    private static WeakReference<Context> weakContext;\n\n` +
+        `    public static Context getContext() {\n` +
+        `        return weakContext != null ? weakContext.get() : null;\n` +
+        `    }\n`
+    );
+
+    // Insert weakContext assignment inside onCreate
+    content = content.replace(
+      /super\.onCreate\(savedInstanceState\);/,
+      `super.onCreate(savedInstanceState);\n        weakContext = new WeakReference<>(this);`
+    );
+
+    fs.writeFileSync(mainActivityPath, content, 'utf-8');
+  } catch (err) {
+    console.error('[Cordova Hook] ❌ Failed to patch MainActivity:', err.message);
+  }
+}
+
 
 /**
  * Copy directory recursively

--- a/package-lock.json
+++ b/package-lock.json
@@ -10796,6 +10796,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "src/plugins/proot": {
+      "name": "com.foxdebug.acode.rk.exec.proot",
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "MIT"
+    },
     "src/plugins/sdcard": {
       "name": "cordova-plugin-sdcard",
       "version": "1.1.0",

--- a/readme.md
+++ b/readme.md
@@ -60,8 +60,11 @@ yarn setup
 2. Build the project:
 
 ```shell
-yarn build <platform (android)> <free|paid> <p|prod|d|dev>
+yarn build <free|paid> <p|prod|d|dev> [fdroid]
 ```
+
+**Note**: Add the fdroid flag only if you want to build the F-Droid-compatible version of Acode.
+Omit this flag to build the regular APK (Play Store or normal version).
 
 ## • Contributing
 

--- a/utils/scripts/build.sh
+++ b/utils/scripts/build.sh
@@ -1,14 +1,21 @@
 #! /bin/bash
 
-platform="$1"
-app="$2"
-mode="$3"
+app="$1"
+mode="$2"
+fdroidFlag="$3"
 webpackmode="development"
 cordovamode=""
 
-if [ -z "$platform" ]
-then
-platform="android"
+root=$(npm prefix)
+
+
+if [[ "$fdroidFlag" == "fdroid" ]]; then
+  echo "true" > "$root/fdroid.bool"
+  cordova plugin remove com.foxdebug.acode.rk.exec.proot
+ 
+else
+  echo "false" > "$root/fdroid.bool"
+  cordova plugin add src/plugins/proot/
 fi
 
 if [ -z "$mode" ]
@@ -33,7 +40,7 @@ NC=''
 script1="node ./utils/config.js $mode $app"
 script2="webpack --progress --mode $webpackmode "
 script3="node ./utils/loadStyles.js"
-script4="cordova build $platform $cordovamode"
+script4="cordova build android $cordovamode"
 eval "
 echo \"${RED}$script1${NC}\";
 $script1;


### PR DESCRIPTION
### Add F-Droid Build Flavor

This PR introduces a new **F-Droid-specific build flavor** with the following changes:

---

### Build Instructions:

```bash
# F-Droid flavor (target API level 28)
npm run build paid dev fdroid

# Normal flavor (target API level 34)
npm run build paid dev
```

---

### Key Differences in F-Droid Flavor:

* **Target API level** is set to **28**, to allow execution as proot libs are not available
* **Prebuilt Proot libraries** are **excluded** from the APK when building the F-Droid flavor, in compliance with F-Droid's packaging rules.
