### PR TITLE
Terminal initrc support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
       },
       "cordova-plugin-websocket": {},
       "cordova-plugin-buildinfo": {},
-      "cordova-plugin-browser": {},
       "cordova-plugin-system": {},
+      "cordova-plugin-browser": {},
       "com.foxdebug.acode.rk.exec.terminal": {}
     },
     "platforms": [

--- a/src/plugins/terminal/scripts/init-alpine.sh
+++ b/src/plugins/terminal/scripts/init-alpine.sh
@@ -2,7 +2,6 @@ set -e  # Exit immediately on Failure
 
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/share/bin:/usr/share/sbin:/usr/local/bin:/usr/local/sbin:/system/bin:/system/xbin:$PREFIX/local/bin
 export PS1="\[\e[38;5;46m\]\u\[\033[39m\]@localhost \[\033[39m\]\w \[\033[0m\]\\$ "
-export PIP_BREAK_SYSTEM_PACKAGES=1
 export HOME=/home
 export TERM=xterm-256color
 required_packages="bash"
@@ -43,7 +42,26 @@ if [ "$#" -eq 0 ]; then
     if [ -e "$PREFIX/alpine/initrc" ]; then
         :
     else
-        touch $PREFIX/alpine/initrc
+        cat <<EOF > "$PREFIX/alpine/initrc"
+
+if [[ -f ~/.bashrc ]]; then
+    source ~/.bashrc
+fi
+
+if [[ -f /etc/bash/bashrc ]]; then
+    source /etc/bash/bashrc
+fi
+
+export PATH=\$PATH:/bin:/sbin:/usr/bin:/usr/sbin:/usr/share/bin:/usr/share/sbin:/usr/local/bin:/usr/local/sbin
+export PS1="\[\e[38;5;46m\]\u\[\e[0m\]@localhost \[\e[0m\]\w \[\e[0m\]\\$ "
+export HOME=/home
+export TERM=xterm-256color
+export SHELL=\$(command -v bash)
+
+
+
+EOF
+
     fi
     
     chmod +x $PREFIX/alpine/initrc

--- a/src/plugins/terminal/scripts/init-alpine.sh
+++ b/src/plugins/terminal/scripts/init-alpine.sh
@@ -29,9 +29,6 @@ if [[ ! -f /linkerconfig/ld.config.txt ]];then
     touch /linkerconfig/ld.config.txt
 fi
 
-[ ! -L /bin/login ] && mv /bin/login /bin/real_login
-ln -sf /bin/bash /bin/login
-
 if [ "$1" = "--installing" ]; then
   mkdir -p $PREFIX/.configured
   echo "Installation completed."
@@ -39,11 +36,18 @@ if [ "$1" = "--installing" ]; then
 fi
 
 
-
 if [ "$#" -eq 0 ]; then
     echo "$$" > $PREFIX/pid
     chmod +x $PREFIX/axs
-    $PREFIX/axs
+    
+    if [ -e "$PREFIX/alpine/initrc" ]; then
+        :
+    else
+        touch $PREFIX/alpine/initrc
+    fi
+    
+    chmod +x $PREFIX/alpine/initrc
+    $PREFIX/axs -c "bash --rcfile /initrc -i"
 else
     exec "$@"
 fi


### PR DESCRIPTION
### Summary

This PR adds support for an `/initrc` file, which is executed automatically whenever a new session is started. Users can customize this file to run commands at session startup, similar to a shell initialization script.

In addition, this script can now be used to change the default shell for the session.

### Changes

* Added support for `/initrc` script, executed at the start of each new session
* Fixed execution of `~/.bashrc`
* Corrected handling of the `$SHELL` environment variable