### PR TITLE
Fix: ED25519 SSH keys not working

### DIFF
--- a/build-extras.gradle
+++ b/build-extras.gradle
@@ -1,5 +1,15 @@
+android {
+    packagingOptions {
+        pickFirst 'META-INF/versions/9/OSGI-INF/MANIFEST.MF'
+    }
+}
+
 configurations {
   all {
       exclude module: 'commons-logging'
+      exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
+      exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
+      exclude group: 'org.bouncycastle', module: 'bcpkix-jdk18on'
+      exclude group: 'org.bouncycastle', module: 'bcprov-jdk18on'
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "@types/url-parse": "^1.4.11",
         "autoprefixer": "^10.4.21",
         "babel-loader": "^10.0.0",
+        "com.foxdebug.acode.rk.exec.proot": "file:src/plugins/proot",
         "com.foxdebug.acode.rk.exec.terminal": "file:src/plugins/terminal",
         "cordova-android": "^14.0.1",
         "cordova-clipboard": "^1.3.0",
@@ -4334,6 +4335,10 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/com.foxdebug.acode.rk.exec.proot": {
+      "resolved": "src/plugins/proot",
+      "link": true
+    },
     "node_modules/com.foxdebug.acode.rk.exec.terminal": {
       "resolved": "src/plugins/terminal",
       "link": true
@@ -4640,9 +4645,9 @@
       }
     },
     "node_modules/cordova-android/node_modules/dedent": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
-      "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.0.tgz",
+      "integrity": "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -11202,7 +11207,7 @@
     "src/plugins/proot": {
       "name": "com.foxdebug.acode.rk.exec.proot",
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT"
     },
     "src/plugins/sdcard": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
       "cordova-clipboard": {},
       "cordova-plugin-device": {},
       "cordova-plugin-file": {},
-      "cordova-plugin-sftp": {},
       "cordova-plugin-server": {},
       "cordova-plugin-ftp": {},
       "cordova-plugin-sdcard": {},
@@ -37,7 +36,9 @@
       "cordova-plugin-buildinfo": {},
       "cordova-plugin-system": {},
       "cordova-plugin-browser": {},
-      "com.foxdebug.acode.rk.exec.terminal": {}
+      "com.foxdebug.acode.rk.exec.terminal": {},
+      "com.foxdebug.acode.rk.exec.proot": {},
+      "cordova-plugin-sftp": {}
     },
     "platforms": [
       "android"
@@ -62,6 +63,7 @@
     "@types/url-parse": "^1.4.11",
     "autoprefixer": "^10.4.21",
     "babel-loader": "^10.0.0",
+    "com.foxdebug.acode.rk.exec.proot": "file:src/plugins/proot",
     "com.foxdebug.acode.rk.exec.terminal": "file:src/plugins/terminal",
     "cordova-android": "^14.0.1",
     "cordova-clipboard": "^1.3.0",

--- a/src/plugins/sftp/plugin.xml
+++ b/src/plugins/sftp/plugin.xml
@@ -26,7 +26,7 @@
 
     <framework src="commons-io:commons-io:2.11.0" />
     <framework src="com.sshtools:maverick-synergy-client:3.1.2" />
-    <framework src="com.sshtools:maverick-bc:3.1.2" />
+<!--    <framework src="com.sshtools:maverick-bc:3.1.2" />-->
     <framework src="org.bouncycastle:bcprov-jdk15to18:1.79" />
     <framework src="org.bouncycastle:bcpkix-jdk15to18:1.79" />
 </plugin>

--- a/src/plugins/sftp/plugin.xml
+++ b/src/plugins/sftp/plugin.xml
@@ -27,4 +27,6 @@
     <framework src="commons-io:commons-io:2.11.0" />
     <framework src="com.sshtools:maverick-synergy-client:3.1.2" />
     <framework src="com.sshtools:maverick-bc:3.1.2" />
+    <framework src="org.bouncycastle:bcprov-jdk15to18:1.79" />
+    <framework src="org.bouncycastle:bcpkix-jdk15to18:1.79" />
 </plugin>

--- a/src/plugins/sftp/src/com/foxdebug/sftp/Sftp.java
+++ b/src/plugins/sftp/src/com/foxdebug/sftp/Sftp.java
@@ -181,8 +181,13 @@ public class Sftp extends CordovaPlugin {
               ContentResolver contentResolver = context.getContentResolver();
               InputStream in = contentResolver.openInputStream(uri);
 
-              com.sshtools.common.logger.Log.getDefaultContext().enableFile(com.sshtools.common.logger.Log.Level.DEBUG, new File("/storage/emulated/0/Android/data/com.foxdebug.acode/synergy.log"));
-//               JCEProvider.enableBouncyCastle(false);
+//            for `appDataDirectory`, Ref: https://developer.android.com/reference/android/content/Context#getExternalFilesDir(java.lang.String)
+//            the absolute path to application-specific directory. May return *null* if shared storage is not currently available.
+              File appDataDirectory = context.getExternalFilesDir(null);
+              if (appDataDirectory != null) {
+                com.sshtools.common.logger.Log.getDefaultContext().enableFile(com.sshtools.common.logger.Log.Level.DEBUG, new File(appDataDirectory + "synergy.log"));
+              }
+//            JCEProvider.enableBouncyCastle(false);
 
               Log.i(TAG, "All Available Security Providers (Security.getProviders() : " + Arrays.toString(Security.getProviders()));
               Log.i(TAG, "All Available Security Providers for ED25519 (Security.getProviders(\"KeyPairGenerator.Ed25519\"\") : " + Arrays.toString(Security.getProviders("KeyPairGenerator.Ed25519")));

--- a/src/plugins/sftp/src/com/foxdebug/sftp/Sftp.java
+++ b/src/plugins/sftp/src/com/foxdebug/sftp/Sftp.java
@@ -185,7 +185,7 @@ public class Sftp extends CordovaPlugin {
 //            the absolute path to application-specific directory. May return *null* if shared storage is not currently available.
               File appDataDirectory = context.getExternalFilesDir(null);
               if (appDataDirectory != null) {
-                com.sshtools.common.logger.Log.getDefaultContext().enableFile(com.sshtools.common.logger.Log.Level.DEBUG, new File(appDataDirectory + "synergy.log"));
+                com.sshtools.common.logger.Log.getDefaultContext().enableFile(com.sshtools.common.logger.Log.Level.DEBUG, new File(appDataDirectory,"synergy.log"));
               }
 //            JCEProvider.enableBouncyCastle(false);
 

--- a/src/plugins/sftp/src/com/foxdebug/sftp/Sftp.java
+++ b/src/plugins/sftp/src/com/foxdebug/sftp/Sftp.java
@@ -33,6 +33,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.channels.UnresolvedAddressException;
 import java.nio.charset.StandardCharsets;
+import java.security.Security;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
@@ -40,6 +41,8 @@ import org.apache.cordova.CordovaWebView;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import java.util.Arrays;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 public class Sftp extends CordovaPlugin {
 
@@ -178,7 +181,12 @@ public class Sftp extends CordovaPlugin {
               ContentResolver contentResolver = context.getContentResolver();
               InputStream in = contentResolver.openInputStream(uri);
 
+              com.sshtools.common.logger.Log.getDefaultContext().enableFile(com.sshtools.common.logger.Log.Level.DEBUG, new File("/storage/emulated/0/Android/data/com.foxdebug.acode/synergy.log"));
               JCEProvider.enableBouncyCastle(true);
+
+              Log.i(TAG, "All Available Security Providers (Security.getProviders() : " + Arrays.toString(Security.getProviders()));
+              Log.i(TAG, "All Available Security Providers for ED25519 (Security.getProviders(\"KeyPairGenerator.Ed25519\"\") : " + Arrays.toString(Security.getProviders("KeyPairGenerator.Ed25519")));
+              Log.i(TAG, "BC Security Provider Name (`Security.getProvider(BouncyCastleProvider.PROVIDER_NAME)`) : " + Security.getProvider(BouncyCastleProvider.PROVIDER_NAME));
 
               SshKeyPair keyPair = null;
               try {

--- a/src/plugins/sftp/src/com/foxdebug/sftp/Sftp.java
+++ b/src/plugins/sftp/src/com/foxdebug/sftp/Sftp.java
@@ -182,11 +182,17 @@ public class Sftp extends CordovaPlugin {
               InputStream in = contentResolver.openInputStream(uri);
 
               com.sshtools.common.logger.Log.getDefaultContext().enableFile(com.sshtools.common.logger.Log.Level.DEBUG, new File("/storage/emulated/0/Android/data/com.foxdebug.acode/synergy.log"));
-              JCEProvider.enableBouncyCastle(true);
+//               JCEProvider.enableBouncyCastle(false);
 
               Log.i(TAG, "All Available Security Providers (Security.getProviders() : " + Arrays.toString(Security.getProviders()));
               Log.i(TAG, "All Available Security Providers for ED25519 (Security.getProviders(\"KeyPairGenerator.Ed25519\"\") : " + Arrays.toString(Security.getProviders("KeyPairGenerator.Ed25519")));
               Log.i(TAG, "BC Security Provider Name (`Security.getProvider(BouncyCastleProvider.PROVIDER_NAME)`) : " + Security.getProvider(BouncyCastleProvider.PROVIDER_NAME));
+              Security.removeProvider("BC");
+              Security.insertProviderAt(new BouncyCastleProvider(), 1);
+
+              Log.i(TAG, "(After Inserting BC) All Available Security Providers (Security.getProviders() : " + Arrays.toString(Security.getProviders()));
+              Log.i(TAG, "(After Inserting BC) All Available Security Providers for ED25519 (Security.getProviders(\"KeyPairGenerator.Ed25519\"\") : " + Arrays.toString(Security.getProviders("KeyPairGenerator.Ed25519")));
+              Log.i(TAG, "(After Inserting BC) BC Security Provider Name (`Security.getProvider(BouncyCastleProvider.PROVIDER_NAME)`) : " + Security.getProvider(BouncyCastleProvider.PROVIDER_NAME));
 
               SshKeyPair keyPair = null;
               try {


### PR DESCRIPTION
# About the Issue

Fixes #1289 , And original https://github.com/Acode-Foundation/Acode/issues/674

The issue can be more clearly visible in the logcat of Android/ADB:

```java.io.IOException: Ed25519 KeyFactory not available``` 

Leading to Errors ```
Invalid passphrase for key file
com.sshtools.common.publickey.InvalidPassphraseException: Ed25519 KeyFactory not available```

# Solution/Workaround

This Pull updates BC to atleast `1.79` (that's a little higher than maverick ssh client's one) while maintaining combability to not BREAK the ssh or sftp client Library.

Attempting to fix those issues mentioned above.

I'll try creating an Issue/inform on maverick after this Pull Request.