### PR TITLE
CI: Nightly Builds

### DIFF
--- a/.github/workflows/community-release-notifier.yml
+++ b/.github/workflows/community-release-notifier.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   discord-release:
-    # if: github.repository_owner == 'Acode-Foundation'
+    if: github.repository_owner == 'Acode-Foundation'
     runs-on: ubuntu-latest
     steps:
     - name: Get Release Content

--- a/.github/workflows/community-release-notifier.yml
+++ b/.github/workflows/community-release-notifier.yml
@@ -3,6 +3,15 @@ on:
   release:
     types: [ released ]
   workflow_call:
+    inputs:
+       tag_name:
+          required: true
+          description: "Release tag_name"
+          type: 'string' 
+       url: 
+          required: true
+          description: "release URL"
+          type: 'string'
     secrets:
       DISCORD_WEBHOOK_RELEASE_NOTES:
         description: 'Discord Webhook for Notifying Releases to Discord'

--- a/.github/workflows/community-release-notifier.yml
+++ b/.github/workflows/community-release-notifier.yml
@@ -1,7 +1,12 @@
 name: community-release-notifier
 on:
   release:
-    types: [released]
+    types: [ released ]
+  workflow_call:
+    secrets:
+      DISCORD_WEBHOOK_RELEASE_NOTES:
+        description: 'Discord Webhook for Notifying Releases to Discord'
+        required: true
 
 jobs:
   discord-release:

--- a/.github/workflows/community-release-notifier.yml
+++ b/.github/workflows/community-release-notifier.yml
@@ -1,7 +1,7 @@
 name: community-release-notifier
 on:
   release:
-    types: [prereleased]
+    types: [released]
 
 jobs:
   discord-release:

--- a/.github/workflows/community-release-notifier.yml
+++ b/.github/workflows/community-release-notifier.yml
@@ -28,7 +28,7 @@ jobs:
       with:
         maxLength: 2000
         stringToTruncate: |
-          📢 Acode [${{ github.event.release.tag_name }}](<${{ github.event.release.url }}>) was just Released 🎉!
+          📢 Acode [${{ github.event.release.tag_name || inputs.tag_name }}](<${{ github.event.release.url || inputs.url }}>) was just Released 🎉!
           
 
     - name: Discord Webhook Action (Publishing)

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -201,7 +201,7 @@
              message: |
                    Preview Release for this, has been built.
          
-         [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/
+                   [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/
              
 
     community-release-notifier:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -51,7 +51,7 @@
         
         - name: Logging & summaries
           run: |
-            echo "::group::Logging
+            echo "::group::Logging" 
             echo "is_PR: ${{ inputs.is_PR }} "
             echo "PR_NUMBER: ${{ inputs.PR_NUMBER }}" 
             echo "env: STORE_FILE_PATH: ${{ env.STORE_FILE_PATH }}" 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -44,7 +44,10 @@
       timeout-minutes: 60
       runs-on: ubuntu-latest
       # if: github.repository_owner == 'Acode-Foundation'
-
+      
+      outputs:
+         release_output: ${{ steps.release.outputs }} 
+         updated_version: ${{ steps.update_version.outputs.UPDATED_VERSION}} 
       steps:
         - name: Fast Fail if secrets are missing
           if: ${{ env.KEYSTORE_CONTENT == '' || env.BUILD_JSON_CONTENT == '' }}
@@ -116,6 +119,7 @@
             echo "Extracted Version: $VERSION"
 
         - name: Append Commit Hash to Version and Update config.xml
+          id: update-version 
           run: |
             SHORT_COMMIT_HASH=$(echo "${{ env.GIT_COMMIT }}" | cut -c 1-7)
             if ${{ inputs.is_PR  || false }}; then 
@@ -131,6 +135,7 @@
             echo "Updated version in config.xml"
             # Output the updated version
             echo "UPDATED_VERSION=$UPDATED_VERSION" >> $GITHUB_ENV
+            echo "UPDATED_VERSION=$UPDATED_VERSION" >> $GITHUB_OUTPUT 
 
         - name: Install Node.js Packages
           run: npm install
@@ -211,5 +216,8 @@
 #      Run only if push tags, or triggered by a schedule
       if: contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@8665ebcd59365b0fd81ccf2834d16d7e409b47c3
+      with:
+         tag_name: ${{ needs.build.outputs.updated_version }}
+         url: ${{ needs.build.outputs.release_output.url }} 
       secrets:
         DISCORD_WEBHOOK_RELEASE_NOTES: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -62,7 +62,7 @@
             
             echo "## 🚀 Build Type: ${{ env.VERSION_LABEL }}" >> $GITHUB_STEP_SUMMARY
             echo "is_PR: ${{ inputs.is_PR }}" >> $GITHUB_STEP_SUMMARY
-            echo "PR_NUMBER: \`${{ inputs.PR_NUMBER }\`" >> $GITHUB_STEP_SUMMARY    
+            echo "PR_NUMBER: \`${{ inputs.PR_NUMBER }} \`" >> $GITHUB_STEP_SUMMARY    
 
         - name: Checkout Repository
           uses: actions/checkout@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -62,7 +62,7 @@
             
             echo "## 🚀 Build Type: ${{ env.VERSION_LABEL }}" >> $GITHUB_STEP_SUMMARY
             echo "is_PR: ${{ inputs.is_PR || 'NOT a PR' }}" >> $GITHUB_STEP_SUMMARY
-            echo "PR_NUMBER: \`${{ inputs.PR_NUMBER || 'not a PR' }} \`" >> $GITHUB_STEP_SUMMARY    
+            echo "PR_NUMBER: **${{ inputs.PR_NUMBER || 'not a PR' }}**" >> $GITHUB_STEP_SUMMARY    
 
         - name: Checkout Repository
           uses: actions/checkout@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -61,8 +61,8 @@
             echo "::endgroup::" 
             
             echo "## 🚀 Build Type: ${{ env.VERSION_LABEL }}" >> $GITHUB_STEP_SUMMARY
-            echo "is_PR: ${{ inputs.is_PR }}" >> $GITHUB_STEP_SUMMARY
-            echo "PR_NUMBER: \`${{ inputs.PR_NUMBER }} \`" >> $GITHUB_STEP_SUMMARY    
+            echo "is_PR: ${{ inputs.is_PR || "NOT a PR" }}" >> $GITHUB_STEP_SUMMARY
+            echo "PR_NUMBER: \`${{ inputs.PR_NUMBER || "not a PR" }} \`" >> $GITHUB_STEP_SUMMARY    
 
         - name: Checkout Repository
           uses: actions/checkout@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -159,6 +159,8 @@
             # If the current commit is the same as the tag, skip updating the tag
             if [ "$TAG_COMMIT" != "${{ env.GIT_COMMIT }}" ]; then
               echo "releaseRequired=true" >> $GITHUB_ENV
+              # export tag commit before updating for change logs comparing. 
+              echo "TAG_COMMIT=$TAG_COMMIT" >> $GITHUB_ENV 
             
               git config --global user.name 'GitHub Actions'
               git config --global user.email 'github-actions@github.com'
@@ -179,7 +181,7 @@
               platforms/android/app/build/outputs/apk/debug/app-debug.apk
             body: |
               Automated Nightly (pre-release) Releases for Today
-              \n\n[Compare Changes](https://github.com/${{ github.repository }}/compare/${{ env.PREV_TAG }}...${{ github.sha }})
+              \n\n[Compare Changes](https://github.com/${{ github.repository }}/compare/${{ env.TAG_COMMIT }}...${{ github.sha }})
 
         - name: Update Last Comment by bot (If ran in PR)
           if: github.event_name == 'workflow_call' && inputs.is_PR

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -216,7 +216,7 @@
       needs: build
 #      Run only if push tags, or triggered by a schedule
       if: contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases
-      uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@8665ebcd59365b0fd81ccf2834d16d7e409b47c3
+      uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@8aa552de6c051baa50ef31306c0ff3b41e66c43e
       with:
          tag_name: ${{ needs.build.outputs.updated_version }}
          url: ${{ needs.build.outputs.release_output.url }} 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -215,7 +215,7 @@
     community-release-notifier:
       needs: build
 #      Run only if push tags, or triggered by a schedule
-      if: (contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases) && ${{ env.releaseRequired == 'true' }}
+      if: ${{ (contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases) && env.releaseRequired == 'true' }}
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@1ee998c253d93dc03a7094977d81d72f569df828
       with:
          tag_name: ${{ needs.build.outputs.updated_version }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -165,7 +165,7 @@
               \n\n[Compare Changes](https://github.com/${{ github.repository }}/compare/${{ env.PREV_TAG }}...${{ github.sha }})
 
         - name: Update Last Comment by bot (If ran in PR)
-          if: github.event_name == 'workflow_call' && (inputs.is_PR || false)
+          if: github.event_name == 'workflow_call' && ${{(inputs.is_PR || false)}} 
           run:
             |
             gh pr comment ${{ inputs.PR_NUMBER }} --edit-last --body "Your Preview Release for this, Has been built \n\n [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,7 +26,7 @@
 
   concurrency:
     # Allow only one workflow per any non-`main` branch.
-    group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}
+    group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}-${{ inputs.is_PR && 'is_PR' || ''}}
     cancel-in-progress: true
 
   env:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -53,8 +53,7 @@
           run: |
             echo "::group::Logging
             echo "is_PR: ${{ inputs.is_PR }} "
-            echo "PR_NUMBER: ${{ inputs.PR_NUMBER }}"
-            #echo "job result var: ${{ jobs.build.result }}" 
+            echo "PR_NUMBER: ${{ inputs.PR_NUMBER }}" 
             echo "(env) STORE_FILE_PATH: ${{ env.STORE_FILE_PATH }}" 
             echo "(env) BUILD_JSON_PATH: ${{ env.BUILD_JSON_PATH }}" 
             echo "(env) VERSION_LABEL: ${{ env. VERSION_LABEL }}"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -215,7 +215,7 @@
     community-release-notifier:
       needs: build
 #      Run only if push tags, or triggered by a schedule
-      if: ${{ (contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases) && env.releaseRequired == 'true' }}
+      if: ${{ (contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases) && needs.build.outputs.release_output_url }}
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@1ee998c253d93dc03a7094977d81d72f569df828
       with:
          tag_name: ${{ needs.build.outputs.updated_version }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -54,9 +54,9 @@
             echo "::group::Logging
             echo "is_PR: ${{ inputs.is_PR }} "
             echo "PR_NUMBER: ${{ inputs.PR_NUMBER }}" 
-            echo "(env) STORE_FILE_PATH: ${{ env.STORE_FILE_PATH }}" 
-            echo "(env) BUILD_JSON_PATH: ${{ env.BUILD_JSON_PATH }}" 
-            echo "(env) VERSION_LABEL: ${{ env. VERSION_LABEL }}"
+            echo "env: STORE_FILE_PATH: ${{ env.STORE_FILE_PATH }}" 
+            echo "env: BUILD_JSON_PATH: ${{ env.BUILD_JSON_PATH }}" 
+            echo "env: VERSION_LABEL: ${{ env. VERSION_LABEL }}"
             echo "github sha: ${{ github.sha }}" 
             echo "::endgroup::" 
             

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -194,6 +194,6 @@
     community-release-notifier:
       needs: build
       if: github.event_name != 'workflow_call'
-      uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml
+      uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@8665ebcd59365b0fd81ccf2834d16d7e409b47c3
       secrets:
         DISCORD_WEBHOOK_RELEASE_NOTES: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -53,6 +53,7 @@
         - name: Logging & summaries
           run: |
             echo "::group::Logging" 
+            echo "🎯 github trigger event name: ${{ github.event_name }}"
             echo "is_PR: ${{ inputs.is_PR }} "
             echo "PR_NUMBER: ${{ inputs.PR_NUMBER }}" 
             echo "env: STORE_FILE_PATH: ${{ env.STORE_FILE_PATH }}" 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -215,7 +215,7 @@
     community-release-notifier:
       needs: build
 #      Run only if push tags, or triggered by a schedule
-      if: (contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases) && env.releaseRequired == 'true'
+      if: (contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases) && ${{ env.releaseRequired == 'true' }}
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@1ee998c253d93dc03a7094977d81d72f569df828
       with:
          tag_name: ${{ needs.build.outputs.updated_version }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -54,7 +54,7 @@
             echo "::group::Logging
             echo "is_PR: ${{ inputs.is_PR }} "
             echo "PR_NUMBER: ${{ inputs.PR_NUMBER }}"
-            echo "job result var: ${{ jobs.build.result }}" 
+            #echo "job result var: ${{ jobs.build.result }}" 
             echo "(env) STORE_FILE_PATH: ${{ env.STORE_FILE_PATH }}" 
             echo "(env) BUILD_JSON_PATH: ${{ env.BUILD_JSON_PATH }}" 
             echo "(env) VERSION_LABEL: ${{ env. VERSION_LABEL }}"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -181,7 +181,7 @@
 
         - name: Release Nightly Version
 #          Only run this step, if not called from another workflow. And a previous step is successful with releasedRequired=true
-          if: ! inputs.skip_tagging_and_releases && success() && env.releaseRequired == 'true'
+          if: ${{ ! inputs.skip_tagging_and_releases && success() && env.releaseRequired == 'true' }}
           uses: softprops/action-gh-release@v2
           with:
             prerelease: true

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -130,6 +130,7 @@
         
         - name: Check Nightly Tag and Force Update
           #if: github.event_name == 'push' && contains(github.event.ref, 'tags/nightly') == false
+          if: github.event_name != 'workflow_call'
           run: |
             # Check if the nightly tag exists and get the commit it points to
             if git show-ref --quiet refs/tags/nightly; then
@@ -164,7 +165,7 @@
               \n\n[Compare Changes](https://github.com/${{ github.repository }}/compare/${{ env.PREV_TAG }}...${{ github.sha }})
 
         - name: Update Last Comment by bot (If ran in PR)
-          if: github.event_name == 'workflow_call' && inputs.is_PR || false
+          if: github.event_name == 'workflow_call' && (inputs.is_PR || false)
           run:
             |
             gh pr comment ${{ inputs.PR_NUMBER }} --edit-last --body "Your Preview Release for this, Has been built \n\n [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -65,11 +65,13 @@
             echo "env: BUILD_JSON_PATH: ${{ env.BUILD_JSON_PATH }}" 
             echo "env: VERSION_LABEL: ${{ env. VERSION_LABEL }}"
             echo "github sha: ${{ github.sha }}" 
+            echo "should not skip tags, releases: ${{ ! inputs.skip_tagging_and_releases }} " 
             echo "::endgroup::" 
             
             echo "## 🚀 Build Type: ${{ env.VERSION_LABEL }}" >> $GITHUB_STEP_SUMMARY
             echo "is_PR: ${{ inputs.is_PR || 'NOT a PR' }}" >> $GITHUB_STEP_SUMMARY
-            echo "PR_NUMBER: ${{ inputs.PR_NUMBER || 'not a PR' }}" >> $GITHUB_STEP_SUMMARY    
+            echo "PR_NUMBER: ${{ inputs.PR_NUMBER || 'not a PR' }}" >> $GITHUB_STEP_SUMMARY
+           echo "should not skip tags, releases: ${{ ! inputs.skip_tagging_and_releases }}" >> $GITHUB_STEP_SUMMARY     
 
         - name: Checkout Repository
           uses: actions/checkout@v4
@@ -207,7 +209,7 @@
     community-release-notifier:
       needs: build
 #      Run only if push tags, or triggered by a schedule
-      if: contains(fromJSON('["push", "schedule"]'), github.event_name)
+      if: contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@8665ebcd59365b0fd81ccf2834d16d7e409b47c3
       secrets:
         DISCORD_WEBHOOK_RELEASE_NOTES: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -26,7 +26,7 @@
 
   concurrency:
     # Allow only one workflow per any non-`main` branch.
-    group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}-${{ inputs.is_PR && 'is_PR' || ''}}
+    group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}-${{ inputs.is_PR && 'is_PR' || 'not_PR'}}
     cancel-in-progress: true
 
   env:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -177,6 +177,7 @@
           with:
             prerelease: true
             name: ${{ env.UPDATED_VERSION }}
+            tag_name: ${{ env.UPDATED_VERSION }} 
             files: |
               platforms/android/app/build/outputs/apk/debug/app-debug.apk
             body: |

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -215,10 +215,10 @@
     community-release-notifier:
       needs: build
 #      Run only if push tags, or triggered by a schedule
-      if: contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases
+      if: (contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases) && env.releaseRequired == 'true'
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@1ee998c253d93dc03a7094977d81d72f569df828
       with:
          tag_name: ${{ needs.build.outputs.updated_version }}
-         url: ${{ needs.build.outputs.release_output_url }} 
+         url: ${{ needs.build.outputs.release_output_url }}
       secrets:
         DISCORD_WEBHOOK_RELEASE_NOTES: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,6 +17,10 @@
           required: true
           type: number
           description: The Pull Request that triggered this workflow
+      outputs:
+        job_result:
+          description: "Build job result"
+          value: ${{ jobs.build.result }}
 
     workflow_dispatch:
 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -33,6 +33,7 @@
     STORE_FILE_PATH: /tmp/app-debug.keystore
     BUILD_JSON_PATH: build.json
     VERSION_LABEL: ${{ (inputs.is_PR && 'pr') || 'nightly' }}
+    DISCORD_RELEASE_NOTIFIER_ENABLED: true
   jobs:
     build:
       timeout-minutes: 60
@@ -189,3 +190,10 @@
           run:
             |
             gh pr comment ${{ inputs.PR_NUMBER }} --edit-last --body "Your Preview Release for this, Has been built \n\n [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/"
+
+    community-release-notifier:
+      needs: build
+      if: github.event_name != 'workflow_call' && env.DISCORD_RELEASE_NOTIFIER_ENABLED
+      uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml
+      secrets:
+        DISCORD_WEBHOOK_RELEASE_NOTES: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -193,9 +193,16 @@
 
         - name: Update Last Comment by bot (If ran in PR)
           if: inputs.is_PR
-          run:
-            |
-            gh pr comment ${{ inputs.PR_NUMBER }} --edit-last --body "Your Preview Release for this, Has been built \n\n [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/"
+          uses: marocchino/sticky-pull-request-comment@v2
+          with:
+             hide_and_recreate: true
+             hide_classify: "OUTDATED"
+             header: on-demand-build-status
+             message: |
+                   Preview Release for this, has been built.
+         
+         [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/
+             
 
     community-release-notifier:
       needs: build

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -33,7 +33,7 @@
     STORE_FILE_PATH: /tmp/app-debug.keystore
     BUILD_JSON_PATH: build.json
     VERSION_LABEL: ${{ (inputs.is_PR && 'pr') || 'nightly' }}
-    DISCORD_RELEASE_NOTIFIER_ENABLED: true
+    DISCORD_RELEASE_NOTIFIER_ENABLED: "true"
   jobs:
     build:
       timeout-minutes: 60
@@ -193,7 +193,7 @@
 
     community-release-notifier:
       needs: build
-      if: github.event_name != 'workflow_call' && env.DISCORD_RELEASE_NOTIFIER_ENABLED
+      if: github.event_name != 'workflow_call' && (env.DISCORD_RELEASE_NOTIFIER_ENABLED || '') == 'true'
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml
       secrets:
         DISCORD_WEBHOOK_RELEASE_NOTES: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -17,6 +17,11 @@
           required: true
           type: number
           description: The Pull Request that triggered this workflow
+        skip_tagging_and_releases:
+          required: false
+          default: true
+          type: boolean
+          description: Skips Tagging & releases, since workflow_call isn't available for github.event_name, default is true
       outputs:
         job_result:
           description: "Build job result"
@@ -149,7 +154,7 @@
         
         - name: Check Nightly Tag and Force Update
           #if: github.event_name == 'push' && contains(github.event.ref, 'tags/nightly') == false
-          if: github.event_name != 'workflow_call'
+          if: ${{ ! inputs.skip_tagging_and_releases }}
           run: |
             # Check if the nightly tag exists and get the commit it points to
             if git show-ref --quiet refs/tags/nightly; then
@@ -174,7 +179,7 @@
 
         - name: Release Nightly Version
 #          Only run this step, if not called from another workflow. And a previous step is successful with releasedRequired=true
-          if: github.event_name != 'workflow_call' && success() && env.releaseRequired == 'true'
+          if: ! inputs.skip_tagging_and_releases && success() && env.releaseRequired == 'true'
           uses: softprops/action-gh-release@v2
           with:
             prerelease: true
@@ -187,14 +192,15 @@
               \n\n[Compare Changes](https://github.com/${{ github.repository }}/compare/${{ env.TAG_COMMIT }}...${{ github.sha }})
 
         - name: Update Last Comment by bot (If ran in PR)
-          if: github.event_name == 'workflow_call' && inputs.is_PR
+          if: inputs.is_PR
           run:
             |
             gh pr comment ${{ inputs.PR_NUMBER }} --edit-last --body "Your Preview Release for this, Has been built \n\n [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/"
 
     community-release-notifier:
       needs: build
-      if: github.event_name != 'workflow_call'
+#      Run only if push tags, or triggered by a schedule
+      if: contains(fromJSON('["push", "schedule"]'), github.event_name)
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@8665ebcd59365b0fd81ccf2834d16d7e409b47c3
       secrets:
         DISCORD_WEBHOOK_RELEASE_NOTES: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -46,7 +46,7 @@
       # if: github.repository_owner == 'Acode-Foundation'
       
       outputs:
-         release_output: ${{ steps.release.outputs }} 
+         release_output_url: ${{ steps.release.outputs.url }} 
          updated_version: ${{ steps.update-version.outputs.UPDATED_VERSION}} 
       steps:
         - name: Fast Fail if secrets are missing
@@ -219,6 +219,6 @@
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@8aa552de6c051baa50ef31306c0ff3b41e66c43e
       with:
          tag_name: ${{ needs.build.outputs.updated_version }}
-         url: ${{ needs.build.outputs.release_output.url }} 
+         url: ${{ needs.build.outputs.release_output_url }} 
       secrets:
         DISCORD_WEBHOOK_RELEASE_NOTES: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -48,6 +48,22 @@
           run: |
             echo "::error title=Missing Secrets::KEYSTORE_CONTENT or BUILD_JSON_CONTENT secrets are missing! Aborting workflow."
             exit 1
+        
+        - name: Logging & summaries
+          run: |
+            echo "::group::Logging
+            echo "is_PR: ${{ inputs.is_PR }} "
+            echo "PR_NUMBER: ${{ inputs.PR_NUMBER }}"
+            echo "job result var: ${{ jobs.build.result }}" 
+            echo "(env) STORE_FILE_PATH: ${{ env.STORE_FILE_PATH }}" 
+            echo "(env) BUILD_JSON_PATH: ${{ env.BUILD_JSON_PATH }}" 
+            echo "(env) VERSION_LABEL: ${{ env. VERSION_LABEL }}"
+            echo "github sha: ${{ github.sha }}" 
+            echo "::endgroup::" 
+            
+            echo "## 🚀 Build Type: ${{ env.VERSION_LABEL }}" >> $GITHUB_STEP_SUMMARY
+            echo "is_PR: ${{ inputs.is_PR }}" >> $GITHUB_STEP_SUMMARY
+            echo "PR_NUMBER: \`${{ inputs.PR_NUMBER }\`" >> $GITHUB_STEP_SUMMARY    
 
         - name: Checkout Repository
           uses: actions/checkout@v4
@@ -115,7 +131,9 @@
           run: npm run setup
 
         - name: Run npm build paid dev apk
-          run: npm run build paid dev apk
+          run: |
+             npm run build paid dev apk
+             echo "VERSION: $UPDATED_VERSION" >> $GITHUB_STEP_SUMMARY
 
         - name: Upload APK Artifact
           uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -43,7 +43,7 @@
     build:
       timeout-minutes: 60
       runs-on: ubuntu-latest
-      # if: github.repository_owner == 'Acode-Foundation'
+      if: github.repository_owner == 'Acode-Foundation'
       
       outputs:
          release_output_url: ${{ steps.release.outputs.url }} 
@@ -215,8 +215,8 @@
     community-release-notifier:
       needs: build
 #      Run only if push tags, or triggered by a schedule
-      if: ${{ (contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases) && needs.build.outputs.release_output_url }}
-      uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@1ee998c253d93dc03a7094977d81d72f569df828
+      if: ${{ github.repository_owner == 'Acode-Foundation' && (contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases) && needs.build.outputs.release_output_url }}
+      uses: Acode-Foundation/acode/.github/workflows/community-release-notifier.yml@main
       with:
          tag_name: ${{ needs.build.outputs.updated_version }}
          url: ${{ needs.build.outputs.release_output_url }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -62,7 +62,7 @@
             
             echo "## 🚀 Build Type: ${{ env.VERSION_LABEL }}" >> $GITHUB_STEP_SUMMARY
             echo "is_PR: ${{ inputs.is_PR || 'NOT a PR' }}" >> $GITHUB_STEP_SUMMARY
-            echo "PR_NUMBER: **${{ inputs.PR_NUMBER || 'not a PR' }}**" >> $GITHUB_STEP_SUMMARY    
+            echo "PR_NUMBER: ${{ inputs.PR_NUMBER || 'not a PR' }}" >> $GITHUB_STEP_SUMMARY    
 
         - name: Checkout Repository
           uses: actions/checkout@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -193,7 +193,7 @@
 
     community-release-notifier:
       needs: build
-      if: github.event_name != 'workflow_call' && (env.DISCORD_RELEASE_NOTIFIER_ENABLED || '') == 'true'
+      if: github.event_name != 'workflow_call'
       uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml
       secrets:
         DISCORD_WEBHOOK_RELEASE_NOTES: ${{ secrets.DISCORD_WEBHOOK_RELEASE_NOTES }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -216,7 +216,7 @@
       needs: build
 #      Run only if push tags, or triggered by a schedule
       if: contains(fromJSON('["push", "schedule"]'), github.event_name) || ! inputs.skip_tagging_and_releases
-      uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@8aa552de6c051baa50ef31306c0ff3b41e66c43e
+      uses: unschooledgamer/acode/.github/workflows/community-release-notifier.yml@1ee998c253d93dc03a7094977d81d72f569df828
       with:
          tag_name: ${{ needs.build.outputs.updated_version }}
          url: ${{ needs.build.outputs.release_output_url }} 

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -61,8 +61,8 @@
             echo "::endgroup::" 
             
             echo "## 🚀 Build Type: ${{ env.VERSION_LABEL }}" >> $GITHUB_STEP_SUMMARY
-            echo "is_PR: ${{ inputs.is_PR || "NOT a PR" }}" >> $GITHUB_STEP_SUMMARY
-            echo "PR_NUMBER: \`${{ inputs.PR_NUMBER || "not a PR" }} \`" >> $GITHUB_STEP_SUMMARY    
+            echo "is_PR: ${{ inputs.is_PR || 'NOT a PR' }}" >> $GITHUB_STEP_SUMMARY
+            echo "PR_NUMBER: \`${{ inputs.PR_NUMBER || 'not a PR' }} \`" >> $GITHUB_STEP_SUMMARY    
 
         - name: Checkout Repository
           uses: actions/checkout@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -209,7 +209,7 @@
              message: |
                    Preview Release for this, has been built.
          
-                   [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/
+                   [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})
              
 
     community-release-notifier:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -170,7 +170,7 @@
 
         - name: Release Nightly Version
 #          Only run this step, if not called from another workflow. And a previous step is successful with releasedRequired=true
-          if: github.event_name != 'workflow_call' && (success()) && env.releaseRequired == true
+          if: github.event_name != 'workflow_call' && success() && env.releaseRequired == 'true'
           uses: softprops/action-gh-release@v2
           with:
             prerelease: true
@@ -182,7 +182,7 @@
               \n\n[Compare Changes](https://github.com/${{ github.repository }}/compare/${{ env.PREV_TAG }}...${{ github.sha }})
 
         - name: Update Last Comment by bot (If ran in PR)
-          if: github.event_name == 'workflow_call' && ${{(inputs.is_PR || false)}} 
+          if: github.event_name == 'workflow_call' && inputs.is_PR
           run:
             |
             gh pr comment ${{ inputs.PR_NUMBER }} --edit-last --body "Your Preview Release for this, Has been built \n\n [Click here to view that github actions build](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/"

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -71,7 +71,7 @@
             echo "## 🚀 Build Type: ${{ env.VERSION_LABEL }}" >> $GITHUB_STEP_SUMMARY
             echo "is_PR: ${{ inputs.is_PR || 'NOT a PR' }}" >> $GITHUB_STEP_SUMMARY
             echo "PR_NUMBER: ${{ inputs.PR_NUMBER || 'not a PR' }}" >> $GITHUB_STEP_SUMMARY
-           echo "should not skip tags, releases: ${{ ! inputs.skip_tagging_and_releases }}" >> $GITHUB_STEP_SUMMARY     
+            echo "should not skip tags, releases: ${{ ! inputs.skip_tagging_and_releases }}" >> $GITHUB_STEP_SUMMARY     
 
         - name: Checkout Repository
           uses: actions/checkout@v4

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -47,7 +47,7 @@
       
       outputs:
          release_output: ${{ steps.release.outputs }} 
-         updated_version: ${{ steps.update_version.outputs.UPDATED_VERSION}} 
+         updated_version: ${{ steps.update-version.outputs.UPDATED_VERSION}} 
       steps:
         - name: Fast Fail if secrets are missing
           if: ${{ env.KEYSTORE_CONTENT == '' || env.BUILD_JSON_CONTENT == '' }}
@@ -186,6 +186,7 @@
 
         - name: Release Nightly Version
 #          Only run this step, if not called from another workflow. And a previous step is successful with releasedRequired=true
+          id: release
           if: ${{ ! inputs.skip_tagging_and_releases && success() && env.releaseRequired == 'true' }}
           uses: softprops/action-gh-release@v2
           with:

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -59,7 +59,7 @@ jobs:
   trigger_builder:
       needs: job_trigger
       secrets: inherit
-      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@e55bbe3bdcf70c3544f023dc470ef8e42e1c1066
+      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@256bf1a99d31f5948811dc9eb01de71b7e9d5072
       with:
         is_PR: true
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          clean: false
           fetch-depth: 0
 
       - name: Remove Manually added PR Label

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Trigger Nightly Release Builder Workflow
         id: nightly_release_builder
         continue-on-error: true
-        uses: ./.github/workflows/nightly-build.yml
+        uses: ./.github/workflows/nightly-build.yml@d651aa4a72cde52e5f59fcd5f50a6f4a8766b9f2
         with:
           is_PR: true
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -23,12 +23,13 @@ jobs:
   job_trigger:
     name: Trigger Preview Release (if conditions met)
     if: |
-      (!contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') 
-      && (contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') 
-      || contains(github.event.pull_request.labels.*.name, 'CI: RUN ON-DEMAND PREVIEW RELEASES')))
+        (github.repository_owner == 'Acode-Foundation'
+        && (!contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') 
+        && (contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') 
+        || contains(github.event.pull_request.labels.*.name, 'CI: RUN ON-DEMAND PREVIEW RELEASES')))
+        )
 
     runs-on: ubuntu-latest
-    # if: github.repository_owner == 'Acode-Foundation'
 
     steps:
       - name: Checkout code
@@ -69,7 +70,7 @@ jobs:
   trigger_builder:
       needs: job_trigger
       secrets: inherit
-      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@efe76dff888b30571c1c8a6b75ff648afbc4dcbf
+      uses: Acode-Foundation/acode/.github/workflows/nightly-build.yml@main
       with:
         is_PR: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -78,7 +79,7 @@ jobs:
   update_Last_Comment:
       needs: [job_trigger,trigger_builder]
       runs-on: ubuntu-latest
-      if: ${{ always() && contains(fromJSON('["failure","cancelled"]'), needs.trigger_builder.result) }}
+      if: ${{ github.repository_owner == 'Acode-Foundation' && always() && contains(fromJSON('["failure","cancelled"]'), needs.trigger_builder.result) }}
       steps:
 #        - name: Checkout code
 #          uses: actions/checkout@v4

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -66,10 +66,9 @@ jobs:
   update_Last_Comment:
       needs: [job_trigger,trigger_builder]
       runs-on: ubuntu-latest
-      if: jobs.trigger_builder.result == 'failure'
+      if: ${{ jobs.trigger_builder.result == 'failure' }}
       steps:
         - name: Update Last Comment by bot (if Workflow Triggering failed)
-#        ".outcome" -> result of a completed step before continue-on-error is applied
 
           run: |
             git config --global user.name 'GitHub Actions'

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -59,7 +59,7 @@ jobs:
   trigger_builder:
       needs: job_trigger
       secrets: inherit
-      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@256bf1a99d31f5948811dc9eb01de71b7e9d5072
+      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@9ecb1139e1cf9e8d00997cbeae25a7bc9b4dceea
       with:
         is_PR: true
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -68,7 +68,8 @@ jobs:
   update_Last_Comment:
       needs: [job_trigger,trigger_builder]
       runs-on: ubuntu-latest
-      if: ${{ needs.trigger_builder.result }}
+      if: |
+        ${{ contains(fromJSON('["failure", "cancelled", "skipped"]'), needs.trigger_build.result) }}
       steps:
         - name: Checkout code
           uses: actions/checkout@v4
@@ -83,7 +84,7 @@ jobs:
              hide_classify: "OUTDATED"
              header: on-demand-build-status
              message: |
-                   🔴 (Workflow Trigger failure), Your On-Demand Preview Release/build for ${{ github.event.pull_request.url}}.
-                   status: **\`🔴 failed\`**            
+                   🔴 (Workflow Trigger stopped), Your On-Demand Preview Release/build for ${{ github.event.pull_request.html_url || github.event.pull_request.url }}.
+                   status: **\`${{ needs.trigger_builder.result || 'failure'}}\`**            
 
                    For Owners: Please [Click here to view that github actions](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -59,7 +59,7 @@ jobs:
   trigger_builder:
       needs: job_trigger
       secrets: inherit
-      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@9ecb1139e1cf9e8d00997cbeae25a7bc9b4dceea
+      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@efe76dff888b30571c1c8a6b75ff648afbc4dcbf
       with:
         is_PR: true
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -94,6 +94,7 @@ jobs:
              header: on-demand-build-status
              message: |
                    🔴 (Workflow Trigger stopped), Your On-Demand Preview Release/build for ${{ github.event.pull_request.html_url || github.event.pull_request.url }}.
-                   status: **${{ needs.trigger_builder.result || 'failure'}}**            
-
+                   status: **${{ needs.trigger_builder.result || 'failure'}}**         
+               
+                   ---
                    For Owners: Please [Click here to view that github actions](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -78,16 +78,18 @@ jobs:
   update_Last_Comment:
       needs: [job_trigger,trigger_builder]
       runs-on: ubuntu-latest
-      if: |
-        ${{ contains(fromJSON('["failure", "cancelled", "skipped"]'), needs.trigger_build.result) }}
+      if: ${{ always() }}
       steps:
-        - name: Checkout code
-          uses: actions/checkout@v4
-          with:
-            clean: false
-            fetch-depth: 0
+        - name: Debug upstream result
+          run: echo "trigger_builder result = '${{ needs.trigger_builder.result }}'"
+#        - name: Checkout code
+#          uses: actions/checkout@v4
+#          with:
+#            clean: false
+#            fetch-depth: 0
 
         - name: Update Last Comment by bot (if Workflow Triggering failed)
+          if: ${{ contains(fromJSON('["failure","cancelled","skipped"]'), needs.trigger_builder.result) }}
           uses: marocchino/sticky-pull-request-comment@v2
           with:
              hide_and_recreate: true

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Add comment to PR
         run: |
+            git config --global user.name 'GitHub Actions'
+            git config --global user.email 'github-actions@github.com'
             gh pr comment $PR --body "⚒️ Starting a workflow to build, Your On-Demand Preview Release/build for ${{ github.event.pull_request.url }}. \n\n status: **\`🟡 in_progress\`** \n\n Kindly wait, this message will be updated with success or failure status."
         env:
           PR: ${{ github.event.pull_request.number }}
@@ -56,7 +58,7 @@ jobs:
       - name: Trigger Nightly Release Builder Workflow
         id: nightly_release_builder
         continue-on-error: true
-        uses: ./.github/workflows/nightly-build.yml@ci/nightly-builds
+        uses: ./.github/workflows/nightly-build.yml
         with:
           is_PR: true
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -66,6 +68,8 @@ jobs:
 #        ".outcome" -> result of a completed step before continue-on-error is applied
         if: steps.nightly_release_builder.outcome == 'failure'
         run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'github-actions@github.com'
           gh pr comment --edit-last $PR --body "🔴 (Workflow Trigger failure), Your On-Demand Preview Release/build for ${{ github.event.pull_request.url}}. \n\n status: **\`🔴 failed\`** \n For Owners: Please check the workflow at https://${{ github.server_url }}/${{ github.repository}}/actions"
         env:
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -56,22 +56,25 @@ jobs:
           PR: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Trigger Nightly Release Builder Workflow
-        id: nightly_release_builder
-        continue-on-error: true
-        uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@d651aa4a72cde52e5f59fcd5f50a6f4a8766b9f2
-        with:
-          is_PR: true
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+  trigger_builder:
+      needs: job_trigger
+      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@d651aa4a72cde52e5f59fcd5f50a6f4a8766b9f2
+      with:
+        is_PR: true
+        PR_NUMBER: ${{ github.event.pull_request.number }}
 
-
-      - name: Update Last Comment by bot (if Workflow Triggering failed)
+  update_Last_Comment:
+      needs: [job_trigger,trigger_builder]
+      runs-on: ubuntu-latest
+      if: jobs.trigger_builder.result == 'failure'
+      steps:
+        - name: Update Last Comment by bot (if Workflow Triggering failed)
 #        ".outcome" -> result of a completed step before continue-on-error is applied
-        if: steps.nightly_release_builder.outcome == 'failure'
-        run: |
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'github-actions@github.com'
-          gh pr comment --edit-last $PR --body "🔴 (Workflow Trigger failure), Your On-Demand Preview Release/build for ${{ github.event.pull_request.url}}. \n\n status: **\`🔴 failed\`** \n For Owners: Please check the workflow at https://${{ github.server_url }}/${{ github.repository}}/actions"
-        env:
-          PR: ${{ github.event.pull_request.number }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          run: |
+            git config --global user.name 'GitHub Actions'
+            git config --global user.email 'github-actions@github.com'
+            gh pr comment --edit-last $PR --body "🔴 (Workflow Trigger failure), Your On-Demand Preview Release/build for ${{ github.event.pull_request.url}}. \n\n status: **\`🔴 failed\`** \n For Owners: Please check the workflow at https://${{ github.server_url }}/${{ github.repository}}/actions"
+          env:
+            PR: ${{ github.event.pull_request.number }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -77,11 +77,13 @@ jobs:
             fetch-depth: 0
 
         - name: Update Last Comment by bot (if Workflow Triggering failed)
+          uses: marocchino/sticky-pull-request-comment@v2
+          with:
+             hide_and_recreate: true
+             hide_classify: "OUTDATED"
+             header: on-demand-build-status
+             message: |
+                   🔴 (Workflow Trigger failure), Your On-Demand Preview Release/build for ${{ github.event.pull_request.url}}.
+                   status: **\`🔴 failed\`**            
 
-          run: |
-            git config --global user.name 'GitHub Actions'
-            git config --global user.email 'github-actions@github.com'
-            gh pr comment --edit-last $PR --body "🔴 (Workflow Trigger failure), Your On-Demand Preview Release/build for ${{ github.event.pull_request.url}}. \n\n status: **\`🔴 failed\`** \n For Owners: Please check the workflow at https://${{ github.server_url }}/${{ github.repository}}/actions"
-          env:
-            PR: ${{ github.event.pull_request.number }}
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                   For Owners: Please [Click here to view that github actions](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Trigger Nightly Release Builder Workflow
         id: nightly_release_builder
         continue-on-error: true
-        uses: ./.github/workflows/nightly-build.yml@d651aa4a72cde52e5f59fcd5f50a6f4a8766b9f2
+        uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@d651aa4a72cde52e5f59fcd5f50a6f4a8766b9f2
         with:
           is_PR: true
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -78,10 +78,8 @@ jobs:
   update_Last_Comment:
       needs: [job_trigger,trigger_builder]
       runs-on: ubuntu-latest
-      if: ${{ always() }}
+      if: ${{ always() && contains(fromJSON('["failure","cancelled"]'), needs.trigger_builder.result) }}
       steps:
-        - name: Debug upstream result
-          run: echo "trigger_builder result = '${{ needs.trigger_builder.result }}'"
 #        - name: Checkout code
 #          uses: actions/checkout@v4
 #          with:
@@ -89,7 +87,6 @@ jobs:
 #            fetch-depth: 0
 
         - name: Update Last Comment by bot (if Workflow Triggering failed)
-          if: ${{ contains(fromJSON('["failure","cancelled"]'), needs.trigger_builder.result) }}
           uses: marocchino/sticky-pull-request-comment@v2
           with:
              hide_and_recreate: true

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -69,6 +69,12 @@ jobs:
       runs-on: ubuntu-latest
       if: ${{ needs.trigger_builder.result }}
       steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+          with:
+            clean: false
+            fetch-depth: 0
+
         - name: Update Last Comment by bot (if Workflow Triggering failed)
 
           run: |

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -63,6 +63,7 @@ jobs:
       with:
         is_PR: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
+        skip_tagging_and_releases: true
 
   update_Last_Comment:
       needs: [job_trigger,trigger_builder]

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -66,7 +66,7 @@ jobs:
   update_Last_Comment:
       needs: [job_trigger,trigger_builder]
       runs-on: ubuntu-latest
-      if: ${{ jobs.trigger_builder.result == 'failure' }}
+      if: ${{ needs.trigger_builder.result }}
       steps:
         - name: Update Last Comment by bot (if Workflow Triggering failed)
 

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -59,7 +59,7 @@ jobs:
   trigger_builder:
       needs: job_trigger
       secrets: inherit
-      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@b1a09484dd575b871602a77e59576b234eca47d5
+      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@3abd838c3411a57029c45c926d92bd6d5b727e10
       with:
         is_PR: true
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -59,7 +59,7 @@ jobs:
   trigger_builder:
       needs: job_trigger
       secrets: inherit
-      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@3abd838c3411a57029c45c926d92bd6d5b727e10
+      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@e55bbe3bdcf70c3544f023dc470ef8e42e1c1066
       with:
         is_PR: true
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
             git config --global user.name 'GitHub Actions'
             git config --global user.email 'github-actions@github.com'
-            gh pr comment $PR --body "⚒️ Starting a workflow to build, Your On-Demand Preview Release/build for ${{ github.event.pull_request.url }}. \n\n status: **\`🟡 in_progress\`** \n\n Kindly wait, this message will be updated with success or failure status."
+            gh pr comment $PR --body "⚒️ Starting a workflow to build, Your On-Demand Preview Release/build for ${{ github.event.pull_request.url }}. \n\n status: **\`🟡 in_progress\`** \n\n Kindly wait, this message may be updated with success or failure status."
         env:
           PR: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -58,7 +58,7 @@ jobs:
 
   trigger_builder:
       needs: job_trigger
-      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@d651aa4a72cde52e5f59fcd5f50a6f4a8766b9f2
+      uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@b1a09484dd575b871602a77e59576b234eca47d5
       with:
         is_PR: true
         PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -89,7 +89,7 @@ jobs:
 #            fetch-depth: 0
 
         - name: Update Last Comment by bot (if Workflow Triggering failed)
-          if: ${{ contains(fromJSON('["failure","cancelled","skipped"]'), needs.trigger_builder.result) }}
+          if: ${{ contains(fromJSON('["failure","cancelled"]'), needs.trigger_builder.result) }}
           uses: marocchino/sticky-pull-request-comment@v2
           with:
              hide_and_recreate: true

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -94,6 +94,6 @@ jobs:
              header: on-demand-build-status
              message: |
                    🔴 (Workflow Trigger stopped), Your On-Demand Preview Release/build for ${{ github.event.pull_request.html_url || github.event.pull_request.url }}.
-                   status: **\`${{ needs.trigger_builder.result || 'failure'}}\`**            
+                   status: **${{ needs.trigger_builder.result || 'failure'}}**            
 
-                   For Owners: Please [Click here to view that github actions](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/
+                   For Owners: Please [Click here to view that github actions](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -58,6 +58,7 @@ jobs:
 
   trigger_builder:
       needs: job_trigger
+      secrets: inherit
       uses: unschooledgamer/acode/.github/workflows/nightly-build.yml@b1a09484dd575b871602a77e59576b234eca47d5
       with:
         is_PR: true

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -48,10 +48,20 @@ jobs:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add comment to PR
-        run: |
-            git config --global user.name 'GitHub Actions'
-            git config --global user.email 'github-actions@github.com'
-            gh pr comment $PR --body "⚒️ Starting a workflow to build, Your On-Demand Preview Release/build for ${{ github.event.pull_request.url }}. \n\n status: **\`🟡 in_progress\`** \n\n Kindly wait, this message may be updated with success or failure status."
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          hide_and_recreate: true
+          hide_classify: "OUTDATED"
+          header: on-demand-build-status
+          message: |
+            ⚒️ Starting a workflow to build, Your On-Demand Preview Release/build for ${{ github.event.pull_request.html_url || github.event.pull_request.url }}.
+            
+            status: **\`🟡 in_progress\`**
+            
+            Kindly wait, this message may be updated with success or failure status.
+            
+            For Owners: Please [Click here to view that github actions](https://github.com/${{ github.repository}}/actions/runs/${{ github.run_id }})/
+
         env:
           PR: ${{ github.event.pull_request.number }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request introduces a comprehensive set of CI workflows to support nightly builds and on-demand preview releases for pull requests.

- Adds .github/workflows/nightly-build.yml for scheduled, tag-based, and workflow_call triggered nightly builds, including support for PR-triggered builds with custom version labeling.
- Adds .github/workflows/on-demand-preview-releases-PR.yml to enable maintainers and contributors to trigger preview builds for PRs using labels, with automated PR comments and label management.
- Adds .github/workflows/community-release-notifier.yml for Discord notifications on new releases.
- Ensures secrets management for keystore and build configuration, artifact upload, versioning, and clean-up steps. Required secrets: KEYSTORE_CONTENT, BUILD_JSON_CONTENT, DISCORD_WEBHOOK_RELEASE_NOTES (short base64 values for preview/test can be used for CI testing).
- Designed for compatibility with the Acode-Foundation organization, including permissions, concurrency control, build summary improvements, and CI labels: 'CI: RUN ON-DEMAND PREVIEW RELEASES', 'Bypass check - PREVIEW RELEASE', 'DO NOT PREVIEW RELEASE'.

These changes are intended to streamline the release process, improve CI/CD reliability, and enhance collaboration for both maintainers and contributors.

Apologies for AI generated description 😟, it's due to low battery in my phone, Apologies Once again. Regards, The Code is Written by me.