### PR TITLE
chore: message type detection in release notes script

### DIFF
--- a/utils/scripts/generate-release-notes.js
+++ b/utils/scripts/generate-release-notes.js
@@ -123,7 +123,6 @@ function categorizeCommits(commits, { mergeOnly, importantOnly }) {
 				return (
 					lowerMsg.startsWith(`${k}:`) ||
 					lowerMsg.startsWith(`${k} `) ||
-					lowerMsg.startsWith(`${k}(`) ||
 					lowerMsg.startsWith(`${k}: `) ||
 					lowerMsg.startsWith(`${k}(`) // handles e.g. 'feat(plugin-api): ...'
 				);

--- a/utils/scripts/generate-release-notes.js
+++ b/utils/scripts/generate-release-notes.js
@@ -118,11 +118,16 @@ function categorizeCommits(commits, { mergeOnly, importantOnly }) {
 		if (mergeOnly && !isMerge) continue;
 
 		const type =
-			Object.keys(sections).find(
-				(k) =>
-					msg.toLowerCase().startsWith(`${k}:`) ||
-					msg.toLowerCase().startsWith(`${k} `),
-			) || "other";
+			Object.keys(sections).find((k) => {
+				const lowerMsg = msg.toLowerCase();
+				return (
+					lowerMsg.startsWith(`${k}:`) ||
+					lowerMsg.startsWith(`${k} `) ||
+					lowerMsg.startsWith(`${k}(`) ||
+					lowerMsg.startsWith(`${k}: `) ||
+					lowerMsg.startsWith(`${k}(`) // handles e.g. 'feat(plugin-api): ...'
+				);
+			}) || "other";
 
 		if (
 			importantOnly &&


### PR DESCRIPTION
updates the Release notes script to pick up scoped commits (i.e `feat(plugin)`), instead of ignoring them