### PR TITLE
feat: Razorpay support

### DIFF
--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -51,7 +51,7 @@ class AuthService {
 	}
 
 	async openLoginUrl() {
-		const url = `${constants.BASE_URL}/login?redirect=app`
+		const url = `${constants.BASE_URL}/login?redirect=app`;
 
 		try {
 			await new Promise((resolve, reject) => {

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -50,7 +50,7 @@ class AuthService {
 	}
 
 	async openLoginUrl() {
-		const url = "https://acode.app/login?redirect=app";
+		const url = "https://dev.acode.app/login?redirect=app";
 
 		try {
 			await new Promise((resolve, reject) => {

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -1,5 +1,6 @@
 import toast from "components/toast";
 import { addIntentHandler } from "handlers/intent";
+import constants from "./constants";
 
 const loginEvents = {
 	listeners: new Set(),
@@ -50,7 +51,7 @@ class AuthService {
 	}
 
 	async openLoginUrl() {
-		const url = "https://dev.acode.app/login?redirect=app";
+		const url = `${constants.BASE_URL}/login?redirect=app`
 
 		try {
 			await new Promise((resolve, reject) => {

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -19,7 +19,7 @@ export default {
 	get PLAY_STORE_URL() {
 		return `https://play.google.com/store/apps/details?id=${BuildInfo.packageName}`;
 	},
-	API_BASE: "https://acode.app/api",
+	API_BASE: "https://dev.acode.app/api",
 	// API_BASE: 'https://192.168.0.102:3001/api', // test api
 	SKU_LIST: ["crystal", "bronze", "silver", "gold", "platinum", "titanium"],
 	LOG_FILE_NAME: "Acode.log",

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -19,7 +19,10 @@ export default {
 	get PLAY_STORE_URL() {
 		return `https://play.google.com/store/apps/details?id=${BuildInfo.packageName}`;
 	},
-	API_BASE: "https://dev.acode.app/api",
+
+	//changing url here is not enough, also change in src/plugins/auth/src/android/Authenticator.java
+	BASE_URL: "https://acode.app",
+	API_BASE: `${this.BASE_URL}/api`,
 	// API_BASE: 'https://192.168.0.102:3001/api', // test api
 	SKU_LIST: ["crystal", "bronze", "silver", "gold", "platinum", "titanium"],
 	LOG_FILE_NAME: "Acode.log",

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -22,7 +22,7 @@ export default {
 
 	//changing url here is not enough, also change in src/plugins/auth/src/android/Authenticator.java
 	BASE_URL: "https://acode.app",
-	API_BASE: `${this.BASE_URL}/api`,
+	API_BASE: "https://acode.app/api",
 	// API_BASE: 'https://192.168.0.102:3001/api', // test api
 	SKU_LIST: ["crystal", "bronze", "silver", "gold", "platinum", "titanium"],
 	LOG_FILE_NAME: "Acode.log",

--- a/src/lib/installPlugin.js
+++ b/src/lib/installPlugin.js
@@ -72,8 +72,18 @@ export default async function installPlugin(
 			pluginUrl.startsWith("file:") ||
 			pluginUrl.startsWith("content:")
 		) {
-			// Use fsOperation for Acode registry URL
-			plugin = await fsOperation(pluginUrl).readFile(
+			// Use native downloader for Acode registry URLs (includes auth token)
+			const tempPath = cordova.file.cacheDirectory + "plugin_download.zip";
+			console.log("downloadPluginUrl", pluginUrl, "to", tempPath);
+			
+			await new Promise((resolve, reject) => {
+				cordova.exec(resolve, reject, "Authenticator", "downloadPlugin", [
+					pluginUrl,
+					tempPath,
+				]);
+			});
+
+			plugin = await fsOperation(tempPath).readFile(
 				undefined,
 				(loaded, total) => {
 					loaderDialog.setMessage(
@@ -84,6 +94,7 @@ export default async function installPlugin(
 		} else {
 			const tempPath = cordova.file.cacheDirectory + "plugin_download.zip";
 
+			console.log("downloadPluginUrl", pluginUrl, "to", tempPath);
 			await new Promise((resolve, reject) => {
 				cordova.exec(resolve, reject, "Authenticator", "downloadPlugin", [
 					pluginUrl,

--- a/src/lib/installPlugin.js
+++ b/src/lib/installPlugin.js
@@ -75,7 +75,7 @@ export default async function installPlugin(
 			// Use native downloader for Acode registry URLs (includes auth token)
 			const tempPath = cordova.file.cacheDirectory + "plugin_download.zip";
 			console.log("downloadPluginUrl", pluginUrl, "to", tempPath);
-			
+
 			await new Promise((resolve, reject) => {
 				cordova.exec(resolve, reject, "Authenticator", "downloadPlugin", [
 					pluginUrl,

--- a/src/lib/installPlugin.js
+++ b/src/lib/installPlugin.js
@@ -82,23 +82,23 @@ export default async function installPlugin(
 				},
 			);
 		} else {
-			// cordova http plugin for others
-			plugin = await new Promise((resolve, reject) => {
-				cordova.plugin.http.sendRequest(
+			const tempPath = cordova.file.cacheDirectory + "plugin_download.zip";
+
+			await new Promise((resolve, reject) => {
+				cordova.exec(resolve, reject, "Authenticator", "downloadPlugin", [
 					pluginUrl,
-					{
-						method: "GET",
-						responseType: "arraybuffer",
-					},
-					(response) => {
-						resolve(response.data);
-						loaderDialog.setMessage(`${strings.loading} 100%`);
-					},
-					(error) => {
-						reject(error);
-					},
-				);
+					tempPath,
+				]);
 			});
+
+			plugin = await fsOperation(tempPath).readFile(
+				undefined,
+				(loaded, total) => {
+					loaderDialog.setMessage(
+						`${strings.loading} ${((loaded / total) * 100).toFixed(2)}%`,
+					);
+				},
+			);
 		}
 
 		if (plugin) {

--- a/src/lib/installPlugin.js
+++ b/src/lib/installPlugin.js
@@ -66,51 +66,23 @@ export default async function installPlugin(
 	try {
 		if (!isDependency) loaderDialog.show();
 
-		let plugin;
-		if (
-			pluginUrl.includes(constants.API_BASE) ||
-			pluginUrl.startsWith("file:") ||
-			pluginUrl.startsWith("content:")
-		) {
-			// Use native downloader for Acode registry URLs (includes auth token)
-			const tempPath = cordova.file.cacheDirectory + "plugin_download.zip";
-			console.log("downloadPluginUrl", pluginUrl, "to", tempPath);
+		const tempPath = cordova.file.cacheDirectory + "plugin_download.zip";
 
-			await new Promise((resolve, reject) => {
-				cordova.exec(resolve, reject, "Authenticator", "downloadPlugin", [
-					pluginUrl,
-					tempPath,
-				]);
-			});
+		await new Promise((resolve, reject) => {
+			cordova.exec(resolve, reject, "Authenticator", "downloadPlugin", [
+				pluginUrl,
+				tempPath,
+			]);
+		});
 
-			plugin = await fsOperation(tempPath).readFile(
-				undefined,
-				(loaded, total) => {
-					loaderDialog.setMessage(
-						`${strings.loading} ${((loaded / total) * 100).toFixed(2)}%`,
-					);
-				},
-			);
-		} else {
-			const tempPath = cordova.file.cacheDirectory + "plugin_download.zip";
-
-			console.log("downloadPluginUrl", pluginUrl, "to", tempPath);
-			await new Promise((resolve, reject) => {
-				cordova.exec(resolve, reject, "Authenticator", "downloadPlugin", [
-					pluginUrl,
-					tempPath,
-				]);
-			});
-
-			plugin = await fsOperation(tempPath).readFile(
-				undefined,
-				(loaded, total) => {
-					loaderDialog.setMessage(
-						`${strings.loading} ${((loaded / total) * 100).toFixed(2)}%`,
-					);
-				},
-			);
-		}
+		let plugin = await fsOperation(tempPath).readFile(
+			undefined,
+			(loaded, total) => {
+				loaderDialog.setMessage(
+					`${strings.loading} ${((loaded / total) * 100).toFixed(2)}%`,
+				);
+			},
+		);
 
 		if (plugin) {
 			const zip = new JSZip();

--- a/src/pages/plugin/plugin.js
+++ b/src/pages/plugin/plugin.js
@@ -139,12 +139,31 @@ export default async function PluginInclude(
 			try {
 				loader.showTitleLoader();
 				if ((await helpers.checkAPIStatus()) && isValidSource(plugin.source)) {
-					const remotePlugin = await fsOperation(
-						constants.API_BASE,
-						`plugin/${id}`,
-					)
-						.readFile("json")
-						.catch(() => null);
+
+
+					const remotePlugin = await new Promise((resolve) => {
+						cordova.exec(
+							(result) => {
+								if (!result) return resolve(null);
+								if (typeof result === "string") {
+									try {
+										return resolve(JSON.parse(result));
+									} catch (err) {
+										console.warn("[Plugin Debug] fetchWithToken invalid JSON:", result.slice(0, 120));
+										return resolve(null);
+									}
+								}
+								resolve(result);
+							},
+							(err) => {
+								console.warn("[Plugin Debug] fetchWithToken native error:", err);
+								resolve(null);
+							},
+							"Authenticator",
+							"fetchWithToken",
+							[Url.join(constants.API_BASE, "plugin", id)],
+						);
+					}).catch(() => null);
 
 					if (cancelled || !remotePlugin) return;
 
@@ -159,24 +178,40 @@ export default async function PluginInclude(
 
 					plugin = Object.assign({}, remotePlugin);
 
-					if (!Number.parseFloat(remotePlugin.price)) return;
+				if (!Number.parseFloat(remotePlugin.price) && !remotePlugin.owned) return;
 
 					isPaid = remotePlugin.price > 0;
+					console.log(`[Plugin Debug] Fetched remotePlugin - id: ${remotePlugin.id}, owned: ${remotePlugin.owned}, price: ${remotePlugin.price}, sku: ${remotePlugin.sku}, isPaid: ${isPaid}`);
+					
 					try {
 						[product] = await helpers.promisify(iap.getProducts, [
 							remotePlugin.sku,
 						]);
+						console.log(`[Plugin Debug] IAP getProducts result - product:`, product);
+						
 						if (product) {
 							const purchase = await getPurchase(product.productId);
 							purchased = !!purchase || remotePlugin.owned;
 							price = product.price;
 							purchaseToken = purchase?.purchaseToken;
+							console.log(`[Plugin Debug] IAP path - purchase found: ${!!purchase}, purchased: ${purchased}, price: ${price}`);
 						} else if (remotePlugin.owned) {
 							purchased = true;
+							price = remotePlugin.price;
+							console.log(`[Plugin Debug] No IAP product but owned=true - purchased: ${purchased}, price: ${price}`);
 						}
 					} catch (error) {
+						console.log(`[Plugin Debug] IAP error:`, error.message);
 						helpers.error(error);
+						// If IAP fails but plugin is owned via Razorpay, mark as purchased
+						if (remotePlugin.owned) {
+							purchased = true;
+							price = remotePlugin.price;
+							console.log(`[Plugin Debug] IAP failed but owned=true - purchased: ${purchased}, price: ${price}`);
+						}
 					}
+					
+					console.log(`[Plugin Debug] Final state before render - isPaid: ${isPaid}, purchased: ${purchased}, price: ${price}, installed: ${installed}`);
 				}
 			} catch (error) {
 				console.error(error);
@@ -323,6 +358,8 @@ export default async function PluginInclude(
 	}
 
 	async function render() {
+		console.log(`[Plugin Render Debug] Values being rendered - isPaid: ${isPaid}, purchased: ${purchased}, price: ${price}, installed: ${installed}, id: ${plugin.id}`);
+		
 		const pluginSettings = settings.uiSettings[`plugin-${plugin.id}`];
 		$page.body = view({
 			...plugin,

--- a/src/pages/plugin/plugin.js
+++ b/src/pages/plugin/plugin.js
@@ -168,7 +168,7 @@ export default async function PluginInclude(
 						]);
 						if (product) {
 							const purchase = await getPurchase(product.productId);
-							purchased = !!purchase;
+							purchased = !!purchase || remotePlugin.owned;
 							price = product.price;
 							purchaseToken = purchase?.purchaseToken;
 						}

--- a/src/pages/plugin/plugin.js
+++ b/src/pages/plugin/plugin.js
@@ -171,6 +171,8 @@ export default async function PluginInclude(
 							purchased = !!purchase || remotePlugin.owned;
 							price = product.price;
 							purchaseToken = purchase?.purchaseToken;
+						} else if (remotePlugin.owned) {
+							purchased = true;
 						}
 					} catch (error) {
 						helpers.error(error);

--- a/src/pages/plugin/plugin.js
+++ b/src/pages/plugin/plugin.js
@@ -139,8 +139,6 @@ export default async function PluginInclude(
 			try {
 				loader.showTitleLoader();
 				if ((await helpers.checkAPIStatus()) && isValidSource(plugin.source)) {
-
-
 					const remotePlugin = await new Promise((resolve) => {
 						cordova.exec(
 							(result) => {
@@ -149,14 +147,20 @@ export default async function PluginInclude(
 									try {
 										return resolve(JSON.parse(result));
 									} catch (err) {
-										console.warn("[Plugin Debug] fetchWithToken invalid JSON:", result.slice(0, 120));
+										console.warn(
+											"[Plugin Debug] fetchWithToken invalid JSON:",
+											result.slice(0, 120),
+										);
 										return resolve(null);
 									}
 								}
 								resolve(result);
 							},
 							(err) => {
-								console.warn("[Plugin Debug] fetchWithToken native error:", err);
+								console.warn(
+									"[Plugin Debug] fetchWithToken native error:",
+									err,
+								);
 								resolve(null);
 							},
 							"Authenticator",
@@ -178,40 +182,41 @@ export default async function PluginInclude(
 
 					plugin = Object.assign({}, remotePlugin);
 
-				if (!Number.parseFloat(remotePlugin.price) && !remotePlugin.owned) return;
+					if (!Number.parseFloat(remotePlugin.price) && !remotePlugin.owned)
+						return;
 
 					isPaid = remotePlugin.price > 0;
-					console.log(`[Plugin Debug] Fetched remotePlugin - id: ${remotePlugin.id}, owned: ${remotePlugin.owned}, price: ${remotePlugin.price}, sku: ${remotePlugin.sku}, isPaid: ${isPaid}`);
-					
+					//console.log(`[Plugin Debug] Fetched remotePlugin - id: ${remotePlugin.id}, owned: ${remotePlugin.owned}, price: ${remotePlugin.price}, sku: ${remotePlugin.sku}, isPaid: ${isPaid}`);
+
 					try {
 						[product] = await helpers.promisify(iap.getProducts, [
 							remotePlugin.sku,
 						]);
-						console.log(`[Plugin Debug] IAP getProducts result - product:`, product);
-						
+						//console.log(`[Plugin Debug] IAP getProducts result - product:`, product);
+
 						if (product) {
 							const purchase = await getPurchase(product.productId);
 							purchased = !!purchase || remotePlugin.owned;
 							price = product.price;
 							purchaseToken = purchase?.purchaseToken;
-							console.log(`[Plugin Debug] IAP path - purchase found: ${!!purchase}, purchased: ${purchased}, price: ${price}`);
+							//console.log(`[Plugin Debug] IAP path - purchase found: ${!!purchase}, purchased: ${purchased}, price: ${price}`);
 						} else if (remotePlugin.owned) {
 							purchased = true;
 							price = remotePlugin.price;
-							console.log(`[Plugin Debug] No IAP product but owned=true - purchased: ${purchased}, price: ${price}`);
+							//console.log(`[Plugin Debug] No IAP product but owned=true - purchased: ${purchased}, price: ${price}`);
 						}
 					} catch (error) {
-						console.log(`[Plugin Debug] IAP error:`, error.message);
+						//console.log(`[Plugin Debug] IAP error:`, error.message);
 						helpers.error(error);
 						// If IAP fails but plugin is owned via Razorpay, mark as purchased
 						if (remotePlugin.owned) {
 							purchased = true;
 							price = remotePlugin.price;
-							console.log(`[Plugin Debug] IAP failed but owned=true - purchased: ${purchased}, price: ${price}`);
+							//console.log(`[Plugin Debug] IAP failed but owned=true - purchased: ${purchased}, price: ${price}`);
 						}
 					}
-					
-					console.log(`[Plugin Debug] Final state before render - isPaid: ${isPaid}, purchased: ${purchased}, price: ${price}, installed: ${installed}`);
+
+					//console.log(`[Plugin Debug] Final state before render - isPaid: ${isPaid}, purchased: ${purchased}, price: ${price}, installed: ${installed}`);
 				}
 			} catch (error) {
 				console.error(error);
@@ -358,8 +363,8 @@ export default async function PluginInclude(
 	}
 
 	async function render() {
-		console.log(`[Plugin Render Debug] Values being rendered - isPaid: ${isPaid}, purchased: ${purchased}, price: ${price}, installed: ${installed}, id: ${plugin.id}`);
-		
+		//console.log(`[Plugin Render Debug] Values being rendered - isPaid: ${isPaid}, purchased: ${purchased}, price: ${price}, installed: ${installed}, id: ${plugin.id}`);
+
 		const pluginSettings = settings.uiSettings[`plugin-${plugin.id}`];
 		$page.body = view({
 			...plugin,

--- a/src/pages/plugin/plugin.view.js
+++ b/src/pages/plugin/plugin.view.js
@@ -281,8 +281,8 @@ function Buttons({
 	buy,
 	minVersionCode,
 }) {
-	console.log(`[Buttons Debug] isPaid: ${isPaid}, installed: ${installed}, update: ${update}, purchased: ${purchased}, price: ${price}, minVersionCode: ${minVersionCode}`);
-	
+	//console.log(`[Buttons Debug] isPaid: ${isPaid}, installed: ${installed}, update: ${update}, purchased: ${purchased}, price: ${price}, minVersionCode: ${minVersionCode}`);
+
 	if (
 		typeof minVersionCode === "number" &&
 		minVersionCode > BuildInfo.versionCode
@@ -332,7 +332,7 @@ function Buttons({
 	}
 
 	if (isPaid && !purchased && price) {
-		console.log(`[Buttons] Showing BUY button - isPaid: true, !purchased: true, price: ${price}`);
+		//console.log(`[Buttons] Showing BUY button - isPaid: true, !purchased: true, price: ${price}`);
 		return (
 			<button data-type="buy" className="btn btn-install" onclick={buy}>
 				<i className="icon cart"></i>
@@ -342,7 +342,7 @@ function Buttons({
 	}
 
 	if (isPaid && !purchased && !price) {
-		console.log(`[Buttons] Showing PRODUCT NOT AVAILABLE - isPaid: true, !purchased: true, !price: true`);
+		//console.log(`[Buttons] Showing PRODUCT NOT AVAILABLE - isPaid: true, !purchased: true, !price: true`);
 		return (
 			<div style={{ margin: "auto" }} className="flex-center">
 				<span
@@ -354,7 +354,7 @@ function Buttons({
 		);
 	}
 
-	console.log(`[Buttons] Showing INSTALL button - falling through to default`);
+	//console.log(`[Buttons] Showing INSTALL button - falling through to default`);
 	return (
 		<button data-type="install" className="btn btn-install" onclick={install}>
 			<i className="icon save_alt"></i>

--- a/src/pages/plugin/plugin.view.js
+++ b/src/pages/plugin/plugin.view.js
@@ -281,6 +281,8 @@ function Buttons({
 	buy,
 	minVersionCode,
 }) {
+	console.log(`[Buttons Debug] isPaid: ${isPaid}, installed: ${installed}, update: ${update}, purchased: ${purchased}, price: ${price}, minVersionCode: ${minVersionCode}`);
+	
 	if (
 		typeof minVersionCode === "number" &&
 		minVersionCode > BuildInfo.versionCode
@@ -330,6 +332,7 @@ function Buttons({
 	}
 
 	if (isPaid && !purchased && price) {
+		console.log(`[Buttons] Showing BUY button - isPaid: true, !purchased: true, price: ${price}`);
 		return (
 			<button data-type="buy" className="btn btn-install" onclick={buy}>
 				<i className="icon cart"></i>
@@ -339,6 +342,7 @@ function Buttons({
 	}
 
 	if (isPaid && !purchased && !price) {
+		console.log(`[Buttons] Showing PRODUCT NOT AVAILABLE - isPaid: true, !purchased: true, !price: true`);
 		return (
 			<div style={{ margin: "auto" }} className="flex-center">
 				<span
@@ -350,6 +354,7 @@ function Buttons({
 		);
 	}
 
+	console.log(`[Buttons] Showing INSTALL button - falling through to default`);
 	return (
 		<button data-type="install" className="btn btn-install" onclick={install}>
 			<i className="icon save_alt"></i>

--- a/src/pages/plugins/plugins.js
+++ b/src/pages/plugins/plugins.js
@@ -619,80 +619,85 @@ async function retrieveFilteredPlugins(filterState) {
     );
     $list.installed.setAttribute("empty-msg", strings["no plugins found"]);
   }
-
 async function getOwned() {
   $list.owned.setAttribute("empty-msg", strings["loading..."]);
 
-  const purchases = await helpers.promisify(iap.getPurchases);
   const disabledMap = settings.value.pluginsDisabled || {};
-
-  // Prevent duplicates
   const addedIds = new Set();
 
-  // Play Store / IAP purchases
-  await Promise.all(
-    purchases.map(async ({ productIds }) => {
-      const [sku] = productIds;
-
-      try {
-        const url = Url.join(constants.API_BASE, "plugin/owned", sku);
-        const plugin = await fsOperation(url).readFile("json");
-
-        if (!plugin || addedIds.has(plugin.id)) return;
-
-        const isInstalled = plugins.installed.find(
-          ({ id }) => id === plugin.id
-        );
-
-        plugin.installed = !!isInstalled;
-
-        if (plugin.installed) {
-          plugin.enabled = disabledMap[plugin.id] !== true;
-          plugin.onToggleEnabled = onToggleEnabled;
-        }
-
-        addedIds.add(plugin.id);
-        plugins.owned.push(plugin);
-        $list.owned.append(<Item {...plugin} updates={updates} />);
-      } catch (err) {
-        console.error("Failed to load owned IAP plugin:", err);
-      }
-    })
-  );
-
-  // Razorpay / external purchases
+  // -------------------
+  // Google Play / IAP
+  // -------------------
   try {
-      const url = withSupportedEditor(
-        `${constants.API_BASE}/plugins?owned=true`
-      );
+    const purchases = await helpers.promisify(iap.getPurchases);
 
-      const ownedPlugins = await fetchPlugins(url);
+    await Promise.all(
+      purchases.map(async ({ productIds }) => {
+        const [sku] = productIds;
 
-      ownedPlugins.forEach((plugin) => {
-        if (!plugin || addedIds.has(plugin.id)) return;
+        try {
+          const url = Url.join(constants.API_BASE, "plugin/owned", sku);
+          const plugin = await fsOperation(url).readFile("json");
 
-        const isInstalled = plugins.installed.find(
-          ({ id }) => id === plugin.id
-        );
+          if (!plugin || addedIds.has(plugin.id)) return;
 
-        plugin.installed = !!isInstalled;
+          const isInstalled = plugins.installed.find(
+            ({ id }) => id === plugin.id
+          );
 
-        if (plugin.installed) {
-          plugin.enabled = disabledMap[plugin.id] !== true;
-          plugin.onToggleEnabled = onToggleEnabled;
+          plugin.installed = !!isInstalled;
+
+          if (plugin.installed) {
+            plugin.enabled = disabledMap[plugin.id] !== true;
+            plugin.onToggleEnabled = onToggleEnabled;
+          }
+
+          addedIds.add(plugin.id);
+          plugins.owned.push(plugin);
+          $list.owned.append(<Item {...plugin} updates={updates} />);
+        } catch (err) {
+          console.error("Failed to load owned IAP plugin:", err);
         }
-
-        addedIds.add(plugin.id);
-        plugins.owned.push(plugin);
-        $list.owned.append(<Item {...plugin} updates={updates} />);
-      });
-    } catch (err) {
-      console.error("Failed to fetch owned plugins:", err);
-    }
-
-    $list.owned.setAttribute("empty-msg", strings["no plugins found"]);
+      })
+    );
+  } catch (err) {
+    console.warn("IAP unavailable, continuing with Razorpay:", err);
   }
 
+  // -------------------
+  // Razorpay purchases
+  // -------------------
+  try {
+    const url = withSupportedEditor(
+      `${constants.API_BASE}/plugins?owned=true`
+    );
+
+    const ownedPlugins = await fetchPlugins(url);
+
+    ownedPlugins.forEach((plugin) => {
+      if (!plugin || addedIds.has(plugin.id)) return;
+
+      const isInstalled = plugins.installed.find(
+        ({ id }) => id === plugin.id
+      );
+
+      plugin.installed = !!isInstalled;
+
+      if (plugin.installed) {
+        plugin.enabled = disabledMap[plugin.id] !== true;
+        plugin.onToggleEnabled = onToggleEnabled;
+      }
+
+      addedIds.add(plugin.id);
+      plugins.owned.push(plugin);
+      $list.owned.append(<Item {...plugin} updates={updates} />);
+    });
+  } catch (err) {
+    console.error("Failed to fetch owned plugins:", err);
+  }
+
+  $list.owned.setAttribute("empty-msg", strings["no plugins found"]);
+}
   function onInstall(plugin) {
     if (updates) return;
 

--- a/src/pages/plugins/plugins.js
+++ b/src/pages/plugins/plugins.js
@@ -416,95 +416,82 @@ export default function PluginsInclude(updates) {
     }
   }
 
-  async function retrieveFilteredPlugins(filterState) {
+  //fetch plugins with the auth token
+  function fetchPlugins(url) {
+    return new Promise((resolve, reject) => {
+        cordova.exec(
+            (items) => resolve(items),
+            (err) => reject(new Error(err)),
+            "Authenticator",
+            "fetchPlugins",
+            [url]
+        );
+    });
+}
+  
+async function retrieveFilteredPlugins(filterState) {
     if (!filterState) return { items: [], hasMore: false };
 
     if (filterState.type === "orderBy") {
-      const page = filterState.nextPage || 1;
-      try {
-        let response;
-        if (filterState.value === "top_rated") {
-          response = await fetch(
-            withSupportedEditor(
-              `${constants.API_BASE}/plugins?explore=random&page=${page}&limit=${LIMIT}`,
-            ),
-          );
-        } else {
-          response = await fetch(
-            withSupportedEditor(
-              `${constants.API_BASE}/plugin?orderBy=${filterState.value}&page=${page}&limit=${LIMIT}`,
-            ),
-          );
+        const page = filterState.nextPage || 1;
+        try {
+            let url;
+            if (filterState.value === "top_rated") {
+                url = withSupportedEditor(`${constants.API_BASE}/plugins?explore=random&page=${page}&limit=${LIMIT}`);
+            } else {
+                url = withSupportedEditor(`${constants.API_BASE}/plugin?orderBy=${filterState.value}&page=${page}&limit=${LIMIT}`);
+            }
+
+            const items = await fetchPlugins(url);
+            filterState.nextPage = page + 1;
+            return { items, hasMore: items.length === LIMIT };
+        } catch (error) {
+            console.error("Failed to fetch ordered plugins:", error);
+            return { items: [], hasMore: false };
         }
-        const items = await response.json();
-        if (!Array.isArray(items)) {
-          return { items: [], hasMore: false };
-        }
-        filterState.nextPage = page + 1;
-        const hasMoreResults = items.length === LIMIT;
-        return { items, hasMore: hasMoreResults };
-      } catch (error) {
-        console.error("Failed to fetch ordered plugins:", error);
-        return { items: [], hasMore: false };
-      }
     }
 
-    if (!Array.isArray(filterState.buffer)) {
-      filterState.buffer = [];
-    }
-    if (filterState.hasMoreSource === undefined) {
-      filterState.hasMoreSource = true;
-    }
-    if (!filterState.nextPage) {
-      filterState.nextPage = 1;
-    }
+    if (!Array.isArray(filterState.buffer)) filterState.buffer = [];
+    if (filterState.hasMoreSource === undefined) filterState.hasMoreSource = true;
+    if (!filterState.nextPage) filterState.nextPage = 1;
 
     const items = [];
 
     while (items.length < LIMIT) {
-      if (filterState.buffer.length) {
-        items.push(filterState.buffer.shift());
-        continue;
-      }
-
-      if (filterState.hasMoreSource === false) break;
-
-      try {
-        const page = filterState.nextPage;
-        const response = await fetch(
-          withSupportedEditor(`${constants.API_BASE}/plugins?page=${page}&limit=${LIMIT}`),
-        );
-        const data = await response.json();
-        filterState.nextPage = page + 1;
-
-        if (!Array.isArray(data) || !data.length) {
-          filterState.hasMoreSource = false;
-          break;
+        if (filterState.buffer.length) {
+            items.push(filterState.buffer.shift());
+            continue;
         }
 
-        if (data.length < LIMIT) {
-          filterState.hasMoreSource = false;
-        }
+        if (filterState.hasMoreSource === false) break;
 
-        const matched = data.filter((plugin) => matchesFilter(plugin, filterState));
-        filterState.buffer.push(...matched);
-      } catch (error) {
-        console.error("Failed to fetch filtered plugins:", error);
-        filterState.hasMoreSource = false;
-        break;
-      }
+        try {
+            const url = withSupportedEditor(`${constants.API_BASE}/plugins?page=${filterState.nextPage}&limit=${LIMIT}`);
+            const data = await fetchPlugins(url); // <-- java call
+            filterState.nextPage++;
+
+            if (!Array.isArray(data) || !data.length) {
+                filterState.hasMoreSource = false;
+                break;
+            }
+
+            if (data.length < LIMIT) filterState.hasMoreSource = false;
+
+            filterState.buffer.push(...data.filter(plugin => matchesFilter(plugin, filterState)));
+        } catch (error) {
+            console.error("Failed to fetch filtered plugins:", error);
+            filterState.hasMoreSource = false;
+            break;
+        }
     }
 
     while (items.length < LIMIT && filterState.buffer.length) {
-      items.push(filterState.buffer.shift());
+        items.push(filterState.buffer.shift());
     }
 
-    const hasMoreResults =
-      (filterState.hasMoreSource !== false && filterState.nextPage) ||
-      filterState.buffer.length > 0;
-
+    const hasMoreResults = (filterState.hasMoreSource !== false && filterState.nextPage) || filterState.buffer.length > 0;
     return { items, hasMore: Boolean(hasMoreResults) };
-  }
+}
 
   function matchesFilter(plugin, filterState) {
     if (!plugin) return false;
@@ -559,6 +546,7 @@ export default function PluginsInclude(updates) {
     return [];
   }
 
+  //auth token is not needed here as this endpoint only returns public plugins and the server handles the filtering based on supported editor
   async function getAllPlugins() {
     if (currentFilter) return;
     if (isLoading || !hasMore) return;
@@ -632,26 +620,76 @@ export default function PluginsInclude(updates) {
     $list.installed.setAttribute("empty-msg", strings["no plugins found"]);
   }
 
-  async function getOwned() {
-    $list.owned.setAttribute("empty-msg", strings["loading..."]);
-    const purchases = await helpers.promisify(iap.getPurchases);
-    const disabledMap = settings.value.pluginsDisabled || {};
+async function getOwned() {
+  $list.owned.setAttribute("empty-msg", strings["loading..."]);
 
-    purchases.forEach(async ({ productIds }) => {
+  const purchases = await helpers.promisify(iap.getPurchases);
+  const disabledMap = settings.value.pluginsDisabled || {};
+
+  // Prevent duplicates
+  const addedIds = new Set();
+
+  // Play Store / IAP purchases
+  await Promise.all(
+    purchases.map(async ({ productIds }) => {
       const [sku] = productIds;
-      const url = Url.join(constants.API_BASE, "plugin/owned", sku);
-      const plugin = await fsOperation(url).readFile("json");
-      const isInstalled = plugins.installed.find(({ id }) => id === plugin.id);
-      plugin.installed = !!isInstalled;
 
-      if (plugin.installed) {
-        plugin.enabled = disabledMap[plugin.id] !== true;
-        plugin.onToggleEnabled = onToggleEnabled;
+      try {
+        const url = Url.join(constants.API_BASE, "plugin/owned", sku);
+        const plugin = await fsOperation(url).readFile("json");
+
+        if (!plugin || addedIds.has(plugin.id)) return;
+
+        const isInstalled = plugins.installed.find(
+          ({ id }) => id === plugin.id
+        );
+
+        plugin.installed = !!isInstalled;
+
+        if (plugin.installed) {
+          plugin.enabled = disabledMap[plugin.id] !== true;
+          plugin.onToggleEnabled = onToggleEnabled;
+        }
+
+        addedIds.add(plugin.id);
+        plugins.owned.push(plugin);
+        $list.owned.append(<Item {...plugin} updates={updates} />);
+      } catch (err) {
+        console.error("Failed to load owned IAP plugin:", err);
       }
+    })
+  );
 
-      plugins.owned.push(plugin);
-      $list.owned.append(<Item {...plugin} updates={updates} />);
-    });
+  // Razorpay / external purchases
+  try {
+      const url = withSupportedEditor(
+        `${constants.API_BASE}/plugins?owned=true`
+      );
+
+      const ownedPlugins = await fetchPlugins(url);
+
+      ownedPlugins.forEach((plugin) => {
+        if (!plugin || addedIds.has(plugin.id)) return;
+
+        const isInstalled = plugins.installed.find(
+          ({ id }) => id === plugin.id
+        );
+
+        plugin.installed = !!isInstalled;
+
+        if (plugin.installed) {
+          plugin.enabled = disabledMap[plugin.id] !== true;
+          plugin.onToggleEnabled = onToggleEnabled;
+        }
+
+        addedIds.add(plugin.id);
+        plugins.owned.push(plugin);
+        $list.owned.append(<Item {...plugin} updates={updates} />);
+      });
+    } catch (err) {
+      console.error("Failed to fetch owned plugins:", err);
+    }
+
     $list.owned.setAttribute("empty-msg", strings["no plugins found"]);
   }
 

--- a/src/pages/plugins/plugins.js
+++ b/src/pages/plugins/plugins.js
@@ -661,7 +661,7 @@ async function getOwned() {
       })
     );
   } catch (err) {
-    console.warn("IAP unavailable, continuing with Razorpay:", err);
+    console.warn("IAP unavailable", err);
   }
 
   // -------------------

--- a/src/plugins/auth/plugin.xml
+++ b/src/plugins/auth/plugin.xml
@@ -13,6 +13,7 @@
         <framework src="androidx.security:security-crypto:1.1.0" />
 
         <source-file src="src/android/Authenticator.java" target-dir="src/com/foxdebug/acode/rk/auth" />
+        <source-file src="src/android/PluginRetriever.java" target-dir="src/com/foxdebug/acode/rk/auth" />
         <source-file src="src/android/EncryptedPreferenceManager.java" target-dir="src/com/foxdebug/acode/rk/auth" />
         
            

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -14,6 +14,7 @@ public class Authenticator extends CordovaPlugin {
     private static final String TAG = "AcodeAuth"; 
     private static final String PREFS_FILENAME = "acode_auth_secure";
     private static final String KEY_TOKEN = "auth_token";
+    private static final String API_BASE = "https://acode.app/api";
     private EncryptedPreferenceManager prefManager;
 
     @Override
@@ -162,8 +163,7 @@ public class Authenticator extends CordovaPlugin {
     private String validateToken(String token) {
         HttpURLConnection conn = null;
         try {
-            Log.d(TAG, "Network Request: Connecting to https://dev.acode.app/api/login");
-            URL url = new URL("https://dev.acode.app/api/login");
+            URL url = new URL(API_BASE + "/login");
             conn = (HttpURLConnection) url.openConnection();
             conn.setRequestProperty("x-auth-token", token);
             conn.setRequestMethod("GET");

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -8,6 +8,7 @@ import org.json.JSONException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Scanner;
+import org.json.JSONObject;
 
 public class Authenticator extends CordovaPlugin {
     private static final String TAG = "AcodeAuth"; 
@@ -134,7 +135,7 @@ public class Authenticator extends CordovaPlugin {
             conn.setRequestProperty("x-auth-token", token);
             conn.setRequestMethod("GET");
             conn.setConnectTimeout(5000);
-            conn.setReadTimeout(5000);  // Add read timeout too
+            conn.setReadTimeout(5000);
             
             int code = conn.getResponseCode();
             Log.d(TAG, "Server responded with status code: " + code);

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -42,31 +42,32 @@ public class Authenticator extends CordovaPlugin {
                 prefManager.setString(KEY_TOKEN, token);
                 callbackContext.success();
                 return true;
-            case "getAllPlugins":
+            case "downloadPlugin":
                 cordova.getThreadPool().execute(() -> {
-                        try {
-                            PluginRetriever.getAllPlugins(args.getInt(0), callbackContext);
-                        } catch (Exception e) {
-                            Log.e(TAG, "getAllPlugins error: " + e.getMessage(), e);
-                            callbackContext.error("Error: " + e.getMessage());
-                        }
-                    });
+                    try {
+                        PluginRetriever.downloadPlugin(
+                            prefManager.getString(KEY_TOKEN, null),
+                            args.getString(0),
+                            args.getString(1),
+                            callbackContext
+                        );
+                    } catch (Exception e) {
+                        Log.e(TAG, "downloadPlugin error: " + e.getMessage(), e);
+                        callbackContext.error("Error: " + e.getMessage());
+                    }
+                });
                 return true;
-            case "retrieveFilteredPlugins":
-                try {
-                    JSONObject filterState = args.length() > 0 ? args.getJSONObject(0) : null;
-                    final JSONObject finalFilterState = filterState;
-                    cordova.getThreadPool().execute(() -> {
-                        try {
-                            PluginRetriever.retrieveFilteredPlugins(prefManager.getString(KEY_TOKEN, null), finalFilterState, callbackContext);
-                        } catch (Exception e) {
-                            Log.e(TAG, "retrieveFilteredPlugins error: " + e.getMessage(), e);
-                            callbackContext.error("Error: " + e.getMessage());
-                        }
-                    });
-                } catch (JSONException e) {
-                    callbackContext.error("Invalid filter JSON: " + e.getMessage());
-                }
+            case "fetchPlugins":
+                cordova.getThreadPool().execute(() -> {
+                    try {
+                        String url = args.getString(0);
+                        JSONArray items = PluginRetriever.fetchJsonArray(url, prefManager.getString(KEY_TOKEN, null));
+                        callbackContext.success(items != null ? items : new JSONArray());
+                    } catch (Exception e) {
+                        Log.e(TAG, "fetchPlugins error: " + e.getMessage(), e);
+                        callbackContext.error("Error: " + e.getMessage());
+                    }
+                });
                 return true;
             default:
                 Log.w(TAG, "Attempted to call unknown action: " + action);

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -42,6 +42,16 @@ public class Authenticator extends CordovaPlugin {
                 prefManager.setString(KEY_TOKEN, token);
                 callbackContext.success();
                 return true;
+            case "getAllPlugins":
+                cordova.getThreadPool().execute(() -> {
+                        try {
+                            PluginRetriever.getAllPlugins(prefManager.getString(KEY_TOKEN, null), args.getInt(0), callbackContext);
+                        } catch (Exception e) {
+                            Log.e(TAG, "getAllPlugins error: " + e.getMessage(), e);
+                            callbackContext.error("Error: " + e.getMessage());
+                        }
+                    });
+                return true;
             case "retrieveFilteredPlugins":
                 try {
                     JSONObject filterState = args.length() > 0 ? args.getJSONObject(0) : null;

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -42,6 +42,28 @@ public class Authenticator extends CordovaPlugin {
                 prefManager.setString(KEY_TOKEN, token);
                 callbackContext.success();
                 return true;
+            case "fetchWithToken":
+                cordova.getThreadPool().execute(() -> {
+                    try {
+                        String url = args.getString(0);
+
+                        String result = PluginRetriever.fetchWithToken(
+                            url,
+                            prefManager.getString(KEY_TOKEN, null)
+                        );
+
+                        if (result != null) {
+                            callbackContext.success(result);
+                        } else {
+                            callbackContext.error("Request failed");
+                        }
+
+                    } catch (Exception e) {
+                        Log.e(TAG, "fetchWithToken error: " + e.getMessage(), e);
+                        callbackContext.error(e.getMessage());
+                    }
+                });
+                return true;
             case "downloadPlugin":
                 cordova.getThreadPool().execute(() -> {
                     try {
@@ -140,8 +162,8 @@ public class Authenticator extends CordovaPlugin {
     private String validateToken(String token) {
         HttpURLConnection conn = null;
         try {
-            Log.d(TAG, "Network Request: Connecting to https://acode.app/api/login");
-            URL url = new URL("https://acode.app/api/login");
+            Log.d(TAG, "Network Request: Connecting to https://dev.acode.app/api/login");
+            URL url = new URL("https://dev.acode.app/api/login");
             conn = (HttpURLConnection) url.openConnection();
             conn.setRequestProperty("x-auth-token", token);
             conn.setRequestMethod("GET");

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -45,7 +45,7 @@ public class Authenticator extends CordovaPlugin {
             case "getAllPlugins":
                 cordova.getThreadPool().execute(() -> {
                         try {
-                            PluginRetriever.getAllPlugins(prefManager.getString(KEY_TOKEN, null), args.getInt(0), callbackContext);
+                            PluginRetriever.getAllPlugins(args.getInt(0), callbackContext);
                         } catch (Exception e) {
                             Log.e(TAG, "getAllPlugins error: " + e.getMessage(), e);
                             callbackContext.error("Error: " + e.getMessage());

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -10,7 +10,6 @@ import java.net.URL;
 import java.util.Scanner;
 
 public class Authenticator extends CordovaPlugin {
-    // Standard practice: use a TAG for easy filtering in Logcat
     private static final String TAG = "AcodeAuth"; 
     private static final String PREFS_FILENAME = "acode_auth_secure";
     private static final String KEY_TOKEN = "auth_token";
@@ -41,6 +40,22 @@ public class Authenticator extends CordovaPlugin {
                 Log.d(TAG, "Saving new token...");
                 prefManager.setString(KEY_TOKEN, token);
                 callbackContext.success();
+                return true;
+            case "retrieveFilteredPlugins":
+                try {
+                    JSONObject filterState = args.length() > 0 ? args.getJSONObject(0) : null;
+                    final JSONObject finalFilterState = filterState;
+                    cordova.getThreadPool().execute(() -> {
+                        try {
+                            PluginRetriever.retrieveFilteredPlugins(prefManager.getString(KEY_TOKEN, null), finalFilterState, callbackContext);
+                        } catch (Exception e) {
+                            Log.e(TAG, "retrieveFilteredPlugins error: " + e.getMessage(), e);
+                            callbackContext.error("Error: " + e.getMessage());
+                        }
+                    });
+                } catch (JSONException e) {
+                    callbackContext.error("Invalid filter JSON: " + e.getMessage());
+                }
                 return true;
             default:
                 Log.w(TAG, "Attempted to call unknown action: " + action);
@@ -114,7 +129,7 @@ public class Authenticator extends CordovaPlugin {
         HttpURLConnection conn = null;
         try {
             Log.d(TAG, "Network Request: Connecting to https://acode.app/api/login");
-            URL url = new URL("https://acode.app/api/login");  // Changed from /api to /api/login
+            URL url = new URL("https://acode.app/api/login");
             conn = (HttpURLConnection) url.openConnection();
             conn.setRequestProperty("x-auth-token", token);
             conn.setRequestMethod("GET");

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -69,6 +69,7 @@ public class PluginRetriever {
             filterState.put("nextPage", page + 1);
             result.put("items", items);
             result.put("hasMore", items.length() == LIMIT);
+            result.put("filterState", filterState);
             callbackContext.success(result);
             return;
         }

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -9,6 +9,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Scanner;
 import android.content.Context;
+import java.io.File;
+import java.io.InputStream;
+import java.io.FileOutputStream;
 
 public class PluginRetriever {
     private static final String TAG = "AcodePluginRetriever";
@@ -68,7 +71,7 @@ public class PluginRetriever {
     }
 
 
-    private static JSONArray fetchJsonArray(String urlString, String token) {
+    public static JSONArray fetchJsonArray(String urlString, String token) {
         HttpURLConnection conn = null;
         try {
             Log.d(TAG, "Fetching: " + urlString);
@@ -80,7 +83,7 @@ public class PluginRetriever {
 
             if (token != null && !token.isEmpty()) {
                 if (url.getHost().endsWith("acode.app")) {
-                    connection.setRequestProperty("x-auth-token", token);
+                    conn.setRequestProperty("x-auth-token", token);
                 } else {
                     Log.w(TAG, "Not adding auth token for untrusted URL: " + url);
                 }

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -126,7 +126,7 @@ public class PluginRetriever {
             
             // Add auth header if token is present
             if (token != null && !token.isEmpty()) {
-                conn.setRequestProperty("x-auth-token", token);
+                conn.setRequestProperty("Authorization", "Bearer " + token);
             }
 
             int code = conn.getResponseCode();

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -126,7 +126,7 @@ public class PluginRetriever {
             
             // Add auth header if token is present
             if (token != null && !token.isEmpty()) {
-                conn.setRequestProperty("Authorization", "Bearer " + token);
+                conn.setRequestProperty("x-auth-token", token);
             }
 
             int code = conn.getResponseCode();

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -168,6 +168,7 @@ public class PluginRetriever {
 
             Scanner s = new Scanner(conn.getInputStream(), "UTF-8").useDelimiter("\\A");
             String body = s.hasNext() ? s.next() : "[]";
+            s.close();
             return new JSONArray(body);
         } catch (Exception e) {
             Log.e(TAG, "fetchJsonArray error: " + e.getMessage(), e);

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -24,6 +24,59 @@ public class PluginRetriever {
     }
 
 
+    public static String fetchWithToken(String urlString, String token) {
+        HttpURLConnection conn = null;
+
+        try {
+            URL url = new URL(urlString);
+            conn = (HttpURLConnection) url.openConnection();
+
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(10000);
+            conn.setReadTimeout(10000);
+
+            if (token != null && !token.isEmpty()) {
+                String host = url.getHost();
+
+                // Only send token to trusted domains
+                if (host != null &&
+                    (host.equals("acode.app") ||
+                    host.endsWith(".acode.app"))) {
+
+                    conn.setRequestProperty("x-auth-token", token);
+                } else {
+                    Log.w(TAG, "Skipping token for untrusted host: " + host);
+                }
+            }
+
+            int code = conn.getResponseCode();
+
+            if (code != HttpURLConnection.HTTP_OK) {
+                Log.w(TAG, "HTTP " + code + " for " + urlString);
+                return null;
+            }
+
+            Scanner scanner =
+                new Scanner(conn.getInputStream(), "UTF-8")
+                    .useDelimiter("\\A");
+
+            String body = scanner.hasNext()
+                ? scanner.next()
+                : "";
+
+            scanner.close();
+
+            return body;
+
+        } catch (Exception e) {
+            Log.e(TAG, "fetchWithToken error: " + e.getMessage(), e);
+            return null;
+
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
+    }
+
 
     public static void downloadPlugin(String token, String pluginUrl, String destFile, CallbackContext callbackContext) {
         HttpURLConnection connection = null;

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -15,8 +15,6 @@ import java.io.FileOutputStream;
 
 public class PluginRetriever {
     private static final String TAG = "AcodePluginRetriever";
-    private static final int LIMIT = 50;
-    private static final String API_BASE = "https://acode.app/api";
     private static final String SUPPORTED_EDITOR = "cm";
 
     

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -26,6 +26,8 @@ public class PluginRetriever {
 
 
     public static void downloadPlugin(String token, String pluginUrl, String destFile, CallbackContext callbackContext) {
+        HttpURLConnection connection = null;
+
         try {
             // Strip file:// prefix if present
             if (destFile.startsWith("file://")) {
@@ -33,8 +35,10 @@ public class PluginRetriever {
             }
 
             URL url = new URL(pluginUrl);
-            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection = (HttpURLConnection) url.openConnection();
             connection.setRequestMethod("GET");
+            connection.setConnectTimeout(15000);
+            connection.setReadTimeout(30000);
 
             if (token != null && !token.isEmpty()) {
                 if (url.getHost().endsWith("acode.app")) {
@@ -46,16 +50,21 @@ public class PluginRetriever {
 
             connection.connect();
 
-            if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
-                callbackContext.error("HTTP error: " + connection.getResponseCode());
+            int responseCode = connection.getResponseCode();
+            if (responseCode != HttpURLConnection.HTTP_OK) {
+                callbackContext.error("HTTP error: " + responseCode);
                 return;
             }
 
             File tempFile = new File(destFile);
-            try (InputStream inputStream = connection.getInputStream();
-                FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+
+            try (
+                InputStream inputStream = connection.getInputStream();
+                FileOutputStream outputStream = new FileOutputStream(tempFile)
+            ) {
                 byte[] buffer = new byte[4096];
                 int bytesRead;
+
                 while ((bytesRead = inputStream.read(buffer)) != -1) {
                     outputStream.write(buffer, 0, bytesRead);
                 }
@@ -65,6 +74,11 @@ public class PluginRetriever {
 
         } catch (Exception e) {
             callbackContext.error("Download failed: " + e.getMessage());
+
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
         }
     }
 

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -8,6 +8,7 @@ import org.json.JSONObject;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Scanner;
+import android.content.Context;
 
 public class PluginRetriever {
     private static final String TAG = "AcodePluginRetriever";
@@ -22,145 +23,50 @@ public class PluginRetriever {
     }
 
 
-    public static void getAllPlugins(int page, CallbackContext callbackContext) {
-        String url = withSupportedEditor(API_BASE + "/plugins?page=" + page + "&limit=" + LIMIT);
-        JSONArray plugins = fetchJsonArray(url, null);
 
+    public static void downloadPlugin(String token, String pluginUrl, String destFile, CallbackContext callbackContext) {
         try {
-            JSONObject result = new JSONObject();
-            if (plugins == null) plugins = new JSONArray();
-            result.put("items", plugins);
-            result.put("hasMore", plugins.length() == LIMIT);
-            callbackContext.success(result);
-        } catch (JSONException e) {
-            Log.e(TAG, "getAllPlugins error: " + e.getMessage(), e);
-            callbackContext.error("Failed to build result: " + e.getMessage());
-        }
-    }
-
-
-
-    public static void retrieveFilteredPlugins(String token, JSONObject filterState, CallbackContext callbackContext) throws Exception {
-        JSONObject result = new JSONObject();
-
-        if (filterState == null) {
-            result.put("items", new JSONArray());
-            result.put("hasMore", false);
-            callbackContext.success(result);
-            return;
-        }
-
-        String type = filterState.optString("type", "");
-
-        if ("orderBy".equals(type)) {
-            int page = filterState.optInt("nextPage", 1);
-            String value = filterState.optString("value", "");
-            String url;
-
-            if ("top_rated".equals(value)) {
-                url = withSupportedEditor(API_BASE + "/plugins?explore=random&page=" + page + "&limit=" + LIMIT);
-            } else {
-                url = withSupportedEditor(API_BASE + "/plugin?orderBy=" + value + "&page=" + page + "&limit=" + LIMIT);
+            // Strip file:// prefix if present
+            if (destFile.startsWith("file://")) {
+                destFile = destFile.substring(7);
             }
 
-            JSONArray items = fetchJsonArray(url, token);
-            if (items == null) items = new JSONArray();
+            URL url = new URL(pluginUrl);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("GET");
 
-            filterState.put("nextPage", page + 1);
-            result.put("items", items);
-            result.put("hasMore", items.length() == LIMIT);
-            result.put("filterState", filterState);
-            callbackContext.success(result);
-            return;
-        }
-
-        if ("owned".equals(type)) {
-            int page = filterState.optInt("nextPage", 1);
-            String url = withSupportedEditor(API_BASE + "/plugins?owned=true&page=" + page + "&limit=" + LIMIT);
-
-            JSONArray items = fetchJsonArray(url, token);
-            if (items == null) items = new JSONArray();
-
-            filterState.put("nextPage", page + 1);
-            result.put("items", items);
-            result.put("hasMore", items.length() == LIMIT);
-            result.put("filterState", filterState);
-            callbackContext.success(result);
-            return;
-        }
-
-        // --- Buffered filter path (verified, author, keywords) ---
-
-        JSONArray buffer = filterState.optJSONArray("buffer");
-        if (buffer == null) {
-            buffer = new JSONArray();
-            filterState.put("buffer", buffer);
-        }
-
-        boolean hasMoreSource = !filterState.has("hasMoreSource") || filterState.getBoolean("hasMoreSource");
-        int nextPage = filterState.optInt("nextPage", 1);
-        if (!filterState.has("nextPage")) {
-            filterState.put("nextPage", 1);
-        }
-
-        JSONArray items = new JSONArray();
-
-        while (items.length() < LIMIT) {
-            if (buffer.length() > 0) {
-                items.put(buffer.get(0));
-                buffer = shiftBuffer(buffer);
-                filterState.put("buffer", buffer);
-                continue;
-            }
-
-            if (!hasMoreSource) break;
-
-            String url = withSupportedEditor(API_BASE + "/plugins?page=" + nextPage + "&limit=" + LIMIT);
-            JSONArray data = fetchJsonArray(url, token);
-            nextPage++;
-            filterState.put("nextPage", nextPage);
-
-            if (data == null || data.length() == 0) {
-                hasMoreSource = false;
-                filterState.put("hasMoreSource", false);
-                break;
-            }
-
-            if (data.length() < LIMIT) {
-                hasMoreSource = false;
-                filterState.put("hasMoreSource", false);
-            }
-
-            for (int i = 0; i < data.length(); i++) {
-                JSONObject plugin = data.getJSONObject(i);
-                if (matchesFilter(plugin, filterState)) {
-                    buffer.put(plugin);
+            if (token != null && !token.isEmpty()) {
+                if (url.getHost().endsWith("acode.app")) {
+                    connection.setRequestProperty("x-auth-token", token);
+                } else {
+                    Log.w(TAG, "Not adding auth token for untrusted URL: " + pluginUrl);
                 }
             }
-            filterState.put("buffer", buffer);
+
+            connection.connect();
+
+            if (connection.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                callbackContext.error("HTTP error: " + connection.getResponseCode());
+                return;
+            }
+
+            File tempFile = new File(destFile);
+            try (InputStream inputStream = connection.getInputStream();
+                FileOutputStream outputStream = new FileOutputStream(tempFile)) {
+                byte[] buffer = new byte[4096];
+                int bytesRead;
+                while ((bytesRead = inputStream.read(buffer)) != -1) {
+                    outputStream.write(buffer, 0, bytesRead);
+                }
+            }
+
+            callbackContext.success();
+
+        } catch (Exception e) {
+            callbackContext.error("Download failed: " + e.getMessage());
         }
-
-        while (items.length() < LIMIT && buffer.length() > 0) {
-            items.put(buffer.get(0));
-            buffer = shiftBuffer(buffer);
-            filterState.put("buffer", buffer);
-        }
-
-        boolean hasMore = (hasMoreSource && filterState.has("nextPage")) || buffer.length() > 0;
-
-        result.put("items", items);
-        result.put("hasMore", hasMore);
-        callbackContext.success(result);
     }
 
-    // Removes first element from JSONArray (mirrors JS Array.shift())
-    private static JSONArray shiftBuffer(JSONArray buffer) throws JSONException {
-        JSONArray newBuffer = new JSONArray();
-        for (int i = 1; i < buffer.length(); i++) {
-            newBuffer.put(buffer.get(i));
-        }
-        return newBuffer;
-    }
 
     private static JSONArray fetchJsonArray(String urlString, String token) {
         HttpURLConnection conn = null;
@@ -173,7 +79,11 @@ public class PluginRetriever {
             conn.setReadTimeout(5000);
 
             if (token != null && !token.isEmpty()) {
-                conn.setRequestProperty("x-auth-token", token);
+                if (url.getHost().endsWith("acode.app")) {
+                    connection.setRequestProperty("x-auth-token", token);
+                } else {
+                    Log.w(TAG, "Not adding auth token for untrusted URL: " + url);
+                }
             }
 
             int code = conn.getResponseCode();
@@ -194,103 +104,6 @@ public class PluginRetriever {
         }
     }
 
-    private static boolean matchesFilter(JSONObject plugin, JSONObject filterState) {
-        try {
-            String type = filterState.optString("type", "");
-
-            switch (type) {
-                case "verified":
-                    // Mirrors JS: Boolean(plugin.author_verified)
-                    return plugin.optBoolean("author_verified", false);
-
-                case "author": {
-                    String filterValue = filterState.optString("value", "").toLowerCase();
-                    if (filterValue.isEmpty()) return true;
-                    String authorName = normalizePluginAuthor(plugin).toLowerCase();
-                    return authorName.contains(filterValue);
-                }
-
-                case "keywords": {
-                    // value is a JSONArray of lowercase keyword strings
-                    JSONArray filterKeywords = filterState.optJSONArray("value");
-                    if (filterKeywords == null || filterKeywords.length() == 0) return true;
-
-                    JSONArray pluginKeywords = normalizePluginKeywords(plugin);
-                    if (pluginKeywords.length() == 0) return false;
-
-                    // JS: filterState.value.some(keyword =>
-                    //       pluginKeywords.some(pk => pk.includes(keyword)))
-                    for (int fi = 0; fi < filterKeywords.length(); fi++) {
-                        String fk = filterKeywords.getString(fi).toLowerCase();
-                        for (int pi = 0; pi < pluginKeywords.length(); pi++) {
-                            String pk = pluginKeywords.getString(pi).toLowerCase();
-                            if (pk.contains(fk)) return true;
-                        }
-                    }
-                    return false;
-                }
-
-                case "search": {
-                    String value = filterState.optString("value", "").toLowerCase();
-                    if (value.isEmpty()) return true;
-                    String name = plugin.optString("name", "").toLowerCase();
-                    String desc = plugin.optString("description", "").toLowerCase();
-                    return name.contains(value) || desc.contains(value);
-                }
-
-                default:
-                    return true;
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "matchesFilter error: " + e.getMessage(), e);
-            return false;
-        }
-    }
-
-    // Mirrors JS normalizePluginAuthor() — author can be string or object
-    private static String normalizePluginAuthor(JSONObject plugin) {
-        try {
-            Object author = plugin.opt("author");
-            if (author == null) return "";
-            if (author instanceof String) return (String) author;
-            if (author instanceof JSONObject) {
-                JSONObject authorObj = (JSONObject) author;
-                String name = authorObj.optString("name", "");
-                if (!name.isEmpty()) return name;
-                String username = authorObj.optString("username", "");
-                if (!username.isEmpty()) return username;
-                return authorObj.optString("github", "");
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "normalizePluginAuthor error: " + e.getMessage(), e);
-        }
-        return "";
-    }
-
-    // Mirrors JS normalizePluginKeywords() — keywords can be array or comma string
-    private static JSONArray normalizePluginKeywords(JSONObject plugin) {
-        try {
-            Object keywords = plugin.opt("keywords");
-            if (keywords == null) return new JSONArray();
-            if (keywords instanceof JSONArray) return (JSONArray) keywords;
-            if (keywords instanceof String) {
-                String kStr = (String) keywords;
-                // Try parsing as JSON array first
-                try {
-                    return new JSONArray(kStr);
-                } catch (JSONException e) {
-                    // Fall back to comma-split
-                    JSONArray result = new JSONArray();
-                    for (String part : kStr.split(",")) {
-                        String trimmed = part.trim();
-                        if (!trimmed.isEmpty()) result.put(trimmed);
-                    }
-                    return result;
-                }
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "normalizePluginKeywords error: " + e.getMessage(), e);
-        }
-        return new JSONArray();
-    }
+  
+    
 }

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -37,7 +37,7 @@ public class PluginRetriever {
                 url = API_BASE + "/plugin?orderBy=" + value + "&page=" + page + "&limit=" + LIMIT;
             }
 
-            JSONArray items = fetchJsonArray(token,url);
+            JSONArray items = fetchJsonArray(url,token);
             if (items == null) items = new JSONArray();
 
             filterState.put("nextPage", page + 1);
@@ -74,7 +74,7 @@ public class PluginRetriever {
             if (!hasMoreSource) break;
 
             String url = API_BASE + "/plugins?page=" + nextPage + "&limit=" + LIMIT;
-            JSONArray data = fetchJsonArray(token,url);
+            JSONArray data = fetchJsonArray(url,token);
             nextPage++;
             filterState.put("nextPage", nextPage);
 

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -15,16 +15,16 @@ public class PluginRetriever {
     private static final String API_BASE = "https://acode.app/api";
     private static final String SUPPORTED_EDITOR = "cm";
 
-    // Appends supported_editor param — mirrors JS withSupportedEditor()
+    
     private static String withSupportedEditor(String url) {
         String separator = url.contains("?") ? "&" : "?";
         return url + separator + "supported_editor=" + SUPPORTED_EDITOR;
     }
 
 
-    public static void getAllPlugins(String token, int page, CallbackContext callbackContext) {
+    public static void getAllPlugins(int page, CallbackContext callbackContext) {
         String url = withSupportedEditor(API_BASE + "/plugins?page=" + page + "&limit=" + LIMIT);
-        JSONArray plugins = fetchJsonArray(url, token);
+        JSONArray plugins = fetchJsonArray(url, null);
 
         try {
             JSONObject result = new JSONObject();
@@ -62,6 +62,21 @@ public class PluginRetriever {
             } else {
                 url = withSupportedEditor(API_BASE + "/plugin?orderBy=" + value + "&page=" + page + "&limit=" + LIMIT);
             }
+
+            JSONArray items = fetchJsonArray(url, token);
+            if (items == null) items = new JSONArray();
+
+            filterState.put("nextPage", page + 1);
+            result.put("items", items);
+            result.put("hasMore", items.length() == LIMIT);
+            result.put("filterState", filterState);
+            callbackContext.success(result);
+            return;
+        }
+
+        if ("owned".equals(type)) {
+            int page = filterState.optInt("nextPage", 1);
+            String url = withSupportedEditor(API_BASE + "/plugins?owned=true&page=" + page + "&limit=" + LIMIT);
 
             JSONArray items = fetchJsonArray(url, token);
             if (items == null) items = new JSONArray();

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -11,10 +11,36 @@ import java.util.Scanner;
 
 public class PluginRetriever {
     private static final String TAG = "AcodePluginRetriever";
-    private static final int LIMIT = 20;
+    private static final int LIMIT = 50;
     private static final String API_BASE = "https://acode.app/api";
+    private static final String SUPPORTED_EDITOR = "cm";
 
-    public static void retrieveFilteredPlugins(String token,JSONObject filterState, CallbackContext callbackContext) throws Exception {
+    // Appends supported_editor param — mirrors JS withSupportedEditor()
+    private static String withSupportedEditor(String url) {
+        String separator = url.contains("?") ? "&" : "?";
+        return url + separator + "supported_editor=" + SUPPORTED_EDITOR;
+    }
+
+
+    public static void getAllPlugins(String token, int page, CallbackContext callbackContext) {
+        String url = withSupportedEditor(API_BASE + "/plugins?page=" + page + "&limit=" + LIMIT);
+        JSONArray plugins = fetchJsonArray(url, token);
+
+        try {
+            JSONObject result = new JSONObject();
+            if (plugins == null) plugins = new JSONArray();
+            result.put("items", plugins);
+            result.put("hasMore", plugins.length() == LIMIT);
+            callbackContext.success(result);
+        } catch (JSONException e) {
+            Log.e(TAG, "getAllPlugins error: " + e.getMessage(), e);
+            callbackContext.error("Failed to build result: " + e.getMessage());
+        }
+    }
+
+
+
+    public static void retrieveFilteredPlugins(String token, JSONObject filterState, CallbackContext callbackContext) throws Exception {
         JSONObject result = new JSONObject();
 
         if (filterState == null) {
@@ -32,12 +58,12 @@ public class PluginRetriever {
             String url;
 
             if ("top_rated".equals(value)) {
-                url = API_BASE + "/plugins?explore=random&page=" + page + "&limit=" + LIMIT;
+                url = withSupportedEditor(API_BASE + "/plugins?explore=random&page=" + page + "&limit=" + LIMIT);
             } else {
-                url = API_BASE + "/plugin?orderBy=" + value + "&page=" + page + "&limit=" + LIMIT;
+                url = withSupportedEditor(API_BASE + "/plugin?orderBy=" + value + "&page=" + page + "&limit=" + LIMIT);
             }
 
-            JSONArray items = fetchJsonArray(url,token);
+            JSONArray items = fetchJsonArray(url, token);
             if (items == null) items = new JSONArray();
 
             filterState.put("nextPage", page + 1);
@@ -46,6 +72,8 @@ public class PluginRetriever {
             callbackContext.success(result);
             return;
         }
+
+        // --- Buffered filter path (verified, author, keywords) ---
 
         JSONArray buffer = filterState.optJSONArray("buffer");
         if (buffer == null) {
@@ -64,17 +92,15 @@ public class PluginRetriever {
         while (items.length() < LIMIT) {
             if (buffer.length() > 0) {
                 items.put(buffer.get(0));
-                JSONArray newBuffer = new JSONArray();
-                for (int i = 1; i < buffer.length(); i++) newBuffer.put(buffer.get(i));
-                buffer = newBuffer;
+                buffer = shiftBuffer(buffer);
                 filterState.put("buffer", buffer);
                 continue;
             }
 
             if (!hasMoreSource) break;
 
-            String url = API_BASE + "/plugins?page=" + nextPage + "&limit=" + LIMIT;
-            JSONArray data = fetchJsonArray(url,token);
+            String url = withSupportedEditor(API_BASE + "/plugins?page=" + nextPage + "&limit=" + LIMIT);
+            JSONArray data = fetchJsonArray(url, token);
             nextPage++;
             filterState.put("nextPage", nextPage);
 
@@ -100,9 +126,7 @@ public class PluginRetriever {
 
         while (items.length() < LIMIT && buffer.length() > 0) {
             items.put(buffer.get(0));
-            JSONArray newBuffer = new JSONArray();
-            for (int i = 1; i < buffer.length(); i++) newBuffer.put(buffer.get(i));
-            buffer = newBuffer;
+            buffer = shiftBuffer(buffer);
             filterState.put("buffer", buffer);
         }
 
@@ -113,7 +137,15 @@ public class PluginRetriever {
         callbackContext.success(result);
     }
 
-    // Change fetchJsonArray signature to accept token
+    // Removes first element from JSONArray (mirrors JS Array.shift())
+    private static JSONArray shiftBuffer(JSONArray buffer) throws JSONException {
+        JSONArray newBuffer = new JSONArray();
+        for (int i = 1; i < buffer.length(); i++) {
+            newBuffer.put(buffer.get(i));
+        }
+        return newBuffer;
+    }
+
     private static JSONArray fetchJsonArray(String urlString, String token) {
         HttpURLConnection conn = null;
         try {
@@ -123,8 +155,7 @@ public class PluginRetriever {
             conn.setRequestMethod("GET");
             conn.setConnectTimeout(5000);
             conn.setReadTimeout(5000);
-            
-            // Add auth header if token is present
+
             if (token != null && !token.isEmpty()) {
                 conn.setRequestProperty("x-auth-token", token);
             }
@@ -149,18 +180,47 @@ public class PluginRetriever {
     private static boolean matchesFilter(JSONObject plugin, JSONObject filterState) {
         try {
             String type = filterState.optString("type", "");
-            String value = filterState.optString("value", "").toLowerCase();
-
-            if (value.isEmpty()) return true;
 
             switch (type) {
-                case "search":
+                case "verified":
+                    // Mirrors JS: Boolean(plugin.author_verified)
+                    return plugin.optBoolean("author_verified", false);
+
+                case "author": {
+                    String filterValue = filterState.optString("value", "").toLowerCase();
+                    if (filterValue.isEmpty()) return true;
+                    String authorName = normalizePluginAuthor(plugin).toLowerCase();
+                    return authorName.contains(filterValue);
+                }
+
+                case "keywords": {
+                    // value is a JSONArray of lowercase keyword strings
+                    JSONArray filterKeywords = filterState.optJSONArray("value");
+                    if (filterKeywords == null || filterKeywords.length() == 0) return true;
+
+                    JSONArray pluginKeywords = normalizePluginKeywords(plugin);
+                    if (pluginKeywords.length() == 0) return false;
+
+                    // JS: filterState.value.some(keyword =>
+                    //       pluginKeywords.some(pk => pk.includes(keyword)))
+                    for (int fi = 0; fi < filterKeywords.length(); fi++) {
+                        String fk = filterKeywords.getString(fi).toLowerCase();
+                        for (int pi = 0; pi < pluginKeywords.length(); pi++) {
+                            String pk = pluginKeywords.getString(pi).toLowerCase();
+                            if (pk.contains(fk)) return true;
+                        }
+                    }
+                    return false;
+                }
+
+                case "search": {
+                    String value = filterState.optString("value", "").toLowerCase();
+                    if (value.isEmpty()) return true;
                     String name = plugin.optString("name", "").toLowerCase();
                     String desc = plugin.optString("description", "").toLowerCase();
                     return name.contains(value) || desc.contains(value);
-                case "author":
-                    String author = plugin.optString("author", "").toLowerCase();
-                    return author.contains(value);
+                }
+
                 default:
                     return true;
             }
@@ -168,5 +228,52 @@ public class PluginRetriever {
             Log.e(TAG, "matchesFilter error: " + e.getMessage(), e);
             return false;
         }
+    }
+
+    // Mirrors JS normalizePluginAuthor() — author can be string or object
+    private static String normalizePluginAuthor(JSONObject plugin) {
+        try {
+            Object author = plugin.opt("author");
+            if (author == null) return "";
+            if (author instanceof String) return (String) author;
+            if (author instanceof JSONObject) {
+                JSONObject authorObj = (JSONObject) author;
+                String name = authorObj.optString("name", "");
+                if (!name.isEmpty()) return name;
+                String username = authorObj.optString("username", "");
+                if (!username.isEmpty()) return username;
+                return authorObj.optString("github", "");
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "normalizePluginAuthor error: " + e.getMessage(), e);
+        }
+        return "";
+    }
+
+    // Mirrors JS normalizePluginKeywords() — keywords can be array or comma string
+    private static JSONArray normalizePluginKeywords(JSONObject plugin) {
+        try {
+            Object keywords = plugin.opt("keywords");
+            if (keywords == null) return new JSONArray();
+            if (keywords instanceof JSONArray) return (JSONArray) keywords;
+            if (keywords instanceof String) {
+                String kStr = (String) keywords;
+                // Try parsing as JSON array first
+                try {
+                    return new JSONArray(kStr);
+                } catch (JSONException e) {
+                    // Fall back to comma-split
+                    JSONArray result = new JSONArray();
+                    for (String part : kStr.split(",")) {
+                        String trimmed = part.trim();
+                        if (!trimmed.isEmpty()) result.put(trimmed);
+                    }
+                    return result;
+                }
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "normalizePluginKeywords error: " + e.getMessage(), e);
+        }
+        return new JSONArray();
     }
 }

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -1,0 +1,172 @@
+package com.foxdebug.acode.rk.auth;
+
+import android.util.Log;
+import org.apache.cordova.CallbackContext;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Scanner;
+
+public class PluginRetriever {
+    private static final String TAG = "AcodePluginRetriever";
+    private static final int LIMIT = 20;
+    private static final String API_BASE = "https://acode.app/api";
+
+    public static void retrieveFilteredPlugins(String token,JSONObject filterState, CallbackContext callbackContext) throws Exception {
+        JSONObject result = new JSONObject();
+
+        if (filterState == null) {
+            result.put("items", new JSONArray());
+            result.put("hasMore", false);
+            callbackContext.success(result);
+            return;
+        }
+
+        String type = filterState.optString("type", "");
+
+        if ("orderBy".equals(type)) {
+            int page = filterState.optInt("nextPage", 1);
+            String value = filterState.optString("value", "");
+            String url;
+
+            if ("top_rated".equals(value)) {
+                url = API_BASE + "/plugins?explore=random&page=" + page + "&limit=" + LIMIT;
+            } else {
+                url = API_BASE + "/plugin?orderBy=" + value + "&page=" + page + "&limit=" + LIMIT;
+            }
+
+            JSONArray items = fetchJsonArray(token,url);
+            if (items == null) items = new JSONArray();
+
+            filterState.put("nextPage", page + 1);
+            result.put("items", items);
+            result.put("hasMore", items.length() == LIMIT);
+            callbackContext.success(result);
+            return;
+        }
+
+        JSONArray buffer = filterState.optJSONArray("buffer");
+        if (buffer == null) {
+            buffer = new JSONArray();
+            filterState.put("buffer", buffer);
+        }
+
+        boolean hasMoreSource = !filterState.has("hasMoreSource") || filterState.getBoolean("hasMoreSource");
+        int nextPage = filterState.optInt("nextPage", 1);
+        if (!filterState.has("nextPage")) {
+            filterState.put("nextPage", 1);
+        }
+
+        JSONArray items = new JSONArray();
+
+        while (items.length() < LIMIT) {
+            if (buffer.length() > 0) {
+                items.put(buffer.get(0));
+                JSONArray newBuffer = new JSONArray();
+                for (int i = 1; i < buffer.length(); i++) newBuffer.put(buffer.get(i));
+                buffer = newBuffer;
+                filterState.put("buffer", buffer);
+                continue;
+            }
+
+            if (!hasMoreSource) break;
+
+            String url = API_BASE + "/plugins?page=" + nextPage + "&limit=" + LIMIT;
+            JSONArray data = fetchJsonArray(token,url);
+            nextPage++;
+            filterState.put("nextPage", nextPage);
+
+            if (data == null || data.length() == 0) {
+                hasMoreSource = false;
+                filterState.put("hasMoreSource", false);
+                break;
+            }
+
+            if (data.length() < LIMIT) {
+                hasMoreSource = false;
+                filterState.put("hasMoreSource", false);
+            }
+
+            for (int i = 0; i < data.length(); i++) {
+                JSONObject plugin = data.getJSONObject(i);
+                if (matchesFilter(plugin, filterState)) {
+                    buffer.put(plugin);
+                }
+            }
+            filterState.put("buffer", buffer);
+        }
+
+        while (items.length() < LIMIT && buffer.length() > 0) {
+            items.put(buffer.get(0));
+            JSONArray newBuffer = new JSONArray();
+            for (int i = 1; i < buffer.length(); i++) newBuffer.put(buffer.get(i));
+            buffer = newBuffer;
+            filterState.put("buffer", buffer);
+        }
+
+        boolean hasMore = (hasMoreSource && filterState.has("nextPage")) || buffer.length() > 0;
+
+        result.put("items", items);
+        result.put("hasMore", hasMore);
+        callbackContext.success(result);
+    }
+
+    // Change fetchJsonArray signature to accept token
+    private static JSONArray fetchJsonArray(String urlString, String token) {
+        HttpURLConnection conn = null;
+        try {
+            Log.d(TAG, "Fetching: " + urlString);
+            URL url = new URL(urlString);
+            conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(5000);
+            
+            // Add auth header if token is present
+            if (token != null && !token.isEmpty()) {
+                conn.setRequestProperty("x-auth-token", token);
+            }
+
+            int code = conn.getResponseCode();
+            if (code != 200) {
+                Log.w(TAG, "Non-200 response (" + code + ") for: " + urlString);
+                return null;
+            }
+
+            Scanner s = new Scanner(conn.getInputStream(), "UTF-8").useDelimiter("\\A");
+            String body = s.hasNext() ? s.next() : "[]";
+            return new JSONArray(body);
+        } catch (Exception e) {
+            Log.e(TAG, "fetchJsonArray error: " + e.getMessage(), e);
+            return null;
+        } finally {
+            if (conn != null) conn.disconnect();
+        }
+    }
+
+    private static boolean matchesFilter(JSONObject plugin, JSONObject filterState) {
+        try {
+            String type = filterState.optString("type", "");
+            String value = filterState.optString("value", "").toLowerCase();
+
+            if (value.isEmpty()) return true;
+
+            switch (type) {
+                case "search":
+                    String name = plugin.optString("name", "").toLowerCase();
+                    String desc = plugin.optString("description", "").toLowerCase();
+                    return name.contains(value) || desc.contains(value);
+                case "author":
+                    String author = plugin.optString("author", "").toLowerCase();
+                    return author.contains(value);
+                default:
+                    return true;
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "matchesFilter error: " + e.getMessage(), e);
+            return false;
+        }
+    }
+}

--- a/src/plugins/auth/src/android/PluginRetriever.java
+++ b/src/plugins/auth/src/android/PluginRetriever.java
@@ -41,10 +41,13 @@ public class PluginRetriever {
             connection.setReadTimeout(30000);
 
             if (token != null && !token.isEmpty()) {
-                if (url.getHost().endsWith("acode.app")) {
+                String host = url.getHost();
+
+                if (host != null &&
+                    (host.equals("acode.app") || host.endsWith(".acode.app"))) {
                     connection.setRequestProperty("x-auth-token", token);
-                } else {
-                    Log.w(TAG, "Not adding auth token for untrusted URL: " + pluginUrl);
+                }else {
+                    Log.w(TAG, "Not adding auth token for untrusted URL: " + url);
                 }
             }
 
@@ -94,9 +97,12 @@ public class PluginRetriever {
             conn.setReadTimeout(5000);
 
             if (token != null && !token.isEmpty()) {
-                if (url.getHost().endsWith("acode.app")) {
+               String host = url.getHost();
+
+                if (host != null &&
+                    (host.equals("acode.app") || host.endsWith(".acode.app"))) {
                     conn.setRequestProperty("x-auth-token", token);
-                } else {
+                }else {
                     Log.w(TAG, "Not adding auth token for untrusted URL: " + url);
                 }
             }


### PR DESCRIPTION
Waiting for https://github.com/Acode-Foundation/acode.app/pull/15 to be merged




## API Expectations

### 1. Plugin Details / Ownership Check

`GET ${constants.API_BASE}/plugin/${id}`

Should return plugin metadata along with an `owned: boolean` field.

The `owned` field is used to indicate that the plugin has already been purchased externally (outside the in-app purchase flow). This allows the client to mark the plugin as purchased even when no in-app purchase record exists.

---

### 2. Owned Plugins Filter

`GET ${constants.API_BASE}/plugins?owned=true`

Should return only plugins that have been purchased externally by the current user.

This is used to fetch plugins the user already owns outside the in-app billing system.

---

### 3. Protected Plugin Download

`GET ${constants.API_BASE}/plugin/download/{pluginId}`

Used to download plugin files after purchase.

When the download URL belongs to `acode.app` or any subdomain of `acode.app`, the client sends the authentication token in the request header:

```http
x-auth-token: <token>
```

### Expected Server Behavior

* Validate the provided token.
* Allow access only to users who own the requested plugin.
* Return the plugin file on success.
* Return an appropriate HTTP error code (`401`, `403`, `404`, etc.) on failure.

### Notes

* Auth headers are only sent to trusted `acode.app` domains.
* External/untrusted URLs will not receive the auth token.
