### PR TITLE
Use evaluateJavascript for uncaught exception logging

### DIFF
--- a/src/plugins/system/android/com/foxdebug/system/System.java
+++ b/src/plugins/system/android/com/foxdebug/system/System.java
@@ -633,14 +633,14 @@ public class System extends CordovaPlugin {
 
     private void sendLogToJavaScript(String level, String message) {
         final String js =
-            "window.log('" + level + "', " + JSONObject.quote(message) + ");";
+            "window.log(" + JSONObject.quote(level) + ", " + JSONObject.quote(message) + ");";
         cordova
             .getActivity()
             .runOnUiThread(
                 new Runnable() {
                     @Override
                     public void run() {
-                        webView.loadUrl("javascript:" + js);
+                        webView.evaluateJavascript(js, null);
                     }
                 }
             );


### PR DESCRIPTION
Closes #2105.

### What changes

`sendLogToJavaScript` in `src/plugins/system/android/com/foxdebug/system/System.java` builds a JS snippet and runs it via `webView.loadUrl("javascript:" + js)`. This is the legacy form of running JS in a WebView. It counts as a navigation, so each call pushes an entry into the WebView back/forward list and races with whatever the page is loading at the time. The recommended replacement is `WebView.evaluateJavascript(script, callback)`, which executes the script without touching navigation. It is available on every API level Acode targets.

While in there, the `level` argument is wrapped with `JSONObject.quote(...)` instead of being interpolated between bare single quotes. The current callers all pass the hardcoded `"error"`, so nothing breaks today, but the helper now stays safe if a future caller passes a level containing a quote or backslash.

```diff
 private void sendLogToJavaScript(String level, String message) {
     final String js =
-        "window.log('" + level + "', " + JSONObject.quote(message) + ");";
+        "window.log(" + JSONObject.quote(level) + ", " + JSONObject.quote(message) + ");";
     cordova
         .getActivity()
         .runOnUiThread(
             new Runnable() {
                 @Override
                 public void run() {
-                    webView.loadUrl("javascript:" + js);
+                    webView.evaluateJavascript(js, null);
                 }
             }
         );
 }
```

The visible behaviour is unchanged: `window.log("error", message)` is still called on the main WebView with the same arguments. Only the transport (and the level-escaping) is updated.
