### PR TITLE
DO NOT MERGE: fix: rename state in fileList component

### DIFF
--- a/src/lib/openFolder.js
+++ b/src/lib/openFolder.js
@@ -655,12 +655,7 @@ function execOperation(type, action, url, $target, name) {
 		}
 
 		newName = Url.basename(newUrl);
-		$target.querySelector(":scope>.text").textContent = newName;
-		$target.dataset.url = newUrl;
-		$target.dataset.name = newName;
 		if (helpers.isFile(type)) {
-			$target.querySelector(":scope>span").className =
-				helpers.getIconForFile(newName);
 			let file = editorManager.getFile(url, "uri");
 			if (file) {
 				file.uri = newUrl;
@@ -668,12 +663,11 @@ function execOperation(type, action, url, $target, name) {
 			}
 		} else {
 			helpers.updateUriOfAllActiveFiles(url, newUrl);
-			//Reloading the folder by collapsing and expanding the folder
-			$target.click(); //collapse
-			$target.click(); //expand
 		}
-		toast(strings.success);
+
 		FileList.rename(url, newUrl);
+		await refreshRenamedEntryInOpenFolders(url, newUrl);
+		toast(strings.success);
 	}
 
 	async function createNew() {
@@ -1086,6 +1080,67 @@ async function refreshOpenFolder(folderUrl) {
 }
 
 /**
+ * Move saved expanded-state keys after a rename.
+ * Supports both exact folder matches and expanded descendants.
+ * @param {string} oldUrl
+ * @param {string} newUrl
+ */
+function migrateOpenFolderStateUrls(oldUrl, newUrl) {
+	if (!oldUrl || !newUrl || oldUrl === newUrl) return;
+
+	const getEntries = (listState) => {
+		if (!listState) return [];
+		if (listState instanceof Map) return Array.from(listState.entries());
+		return Object.entries(listState);
+	};
+	const setEntry = (listState, key, value) => {
+		if (listState instanceof Map) {
+			listState.set(key, value);
+			return;
+		}
+		listState[key] = value;
+	};
+	const deleteEntry = (listState, key) => {
+		if (listState instanceof Map) {
+			listState.delete(key);
+			return;
+		}
+		delete listState[key];
+	};
+
+	addedFolder.forEach(({ listState }) => {
+		const matchingEntries = getEntries(listState).filter(([folderUrl]) => {
+			return folderUrl === oldUrl || folderUrl.startsWith(`${oldUrl}/`);
+		});
+
+		if (!matchingEntries.length) return;
+
+		matchingEntries.forEach(([folderUrl, isExpanded]) => {
+			deleteEntry(listState, folderUrl);
+			setEntry(
+				listState,
+				newUrl + folderUrl.slice(oldUrl.length),
+				isExpanded,
+			);
+		});
+	});
+}
+
+/**
+ * Refresh the affected parent folders after a rename so FileTree state stays in sync with the filesystem.
+ * @param {string} oldUrl
+ * @param {string} newUrl
+ */
+async function refreshRenamedEntryInOpenFolders(oldUrl, newUrl) {
+	if (!oldUrl || !newUrl || oldUrl === newUrl) return;
+
+	migrateOpenFolderStateUrls(oldUrl, newUrl);
+
+	const parentUrls = new Set([Url.dirname(oldUrl), Url.dirname(newUrl)]);
+	await Promise.all(Array.from(parentUrls).map(refreshOpenFolder));
+}
+
+/**
  * Create a folder tile
  * @param {string} name
  * @param {string} url
@@ -1132,29 +1187,10 @@ openFolder.add = async (url, type) => {
 	appendEntryToOpenFolder(parent, url, type);
 };
 
-openFolder.renameItem = (oldFile, newFile, newFilename) => {
+openFolder.renameItem = (oldFile, newFile) => {
 	FileList.rename(oldFile, newFile);
-
 	helpers.updateUriOfAllActiveFiles(oldFile, newFile);
-
-	const filesApp = sidebarApps.get("files");
-	const $els = filesApp.getAll(`[data-url="${oldFile}"]`);
-	Array.from($els).forEach(($el) => {
-		if ($el.dataset.type === "dir") {
-			$el = $el.$title;
-			setTimeout(() => {
-				$el.collapse();
-				$el.expand();
-			}, 0);
-		} else {
-			$el.querySelector(":scope>span").className =
-				helpers.getIconForFile(newFilename);
-		}
-
-		$el.dataset.url = newFile;
-		$el.dataset.name = newFilename;
-		$el.querySelector(":scope>.text").textContent = newFilename;
-	});
+	refreshRenamedEntryInOpenFolders(oldFile, newFile).catch(helpers.error);
 };
 
 openFolder.removeItem = (url) => {

--- a/src/lib/openFolder.js
+++ b/src/lib/openFolder.js
@@ -1139,11 +1139,7 @@ function migrateOpenFolderStateUrls(oldUrl, newUrl) {
 
 		matchingEntries.forEach(([folderUrl, isExpanded]) => {
 			deleteEntry(listState, folderUrl);
-			setEntry(
-				listState,
-				newUrl + folderUrl.slice(oldUrl.length),
-				isExpanded,
-			);
+			setEntry(listState, newUrl + folderUrl.slice(oldUrl.length), isExpanded);
 		});
 	});
 }
@@ -1162,7 +1158,10 @@ async function refreshRenamedEntryInOpenFolders(
 ) {
 	if (!oldUrl || !newUrl || oldUrl === newUrl) return;
 
-	migrateOpenFolderStateUrls(normalizeFolderUrl(oldUrl), normalizeFolderUrl(newUrl));
+	migrateOpenFolderStateUrls(
+		normalizeFolderUrl(oldUrl),
+		normalizeFolderUrl(newUrl),
+	);
 
 	const isAncestorOrSame = (ancestor, descendant) => {
 		if (ancestor === descendant) return true;
@@ -1175,9 +1174,7 @@ async function refreshRenamedEntryInOpenFolders(
 		.filter(Boolean)
 		.filter((parentUrl, index, allParentUrls) => {
 			return !allParentUrls.some((otherUrl, otherIndex) => {
-				return (
-					otherIndex !== index && isAncestorOrSame(otherUrl, parentUrl)
-				);
+				return otherIndex !== index && isAncestorOrSame(otherUrl, parentUrl);
 			});
 		});
 
@@ -1231,7 +1228,7 @@ openFolder.add = async (url, type) => {
 	appendEntryToOpenFolder(parent, url, type);
 };
 
-openFolder.renameItem = (oldFile, newFile) => {
+openFolder.renameItem = (oldFile, newFile, newFilename) => {
 	FileList.rename(oldFile, newFile);
 	helpers.updateUriOfAllActiveFiles(oldFile, newFile);
 	refreshRenamedEntryInOpenFolders(oldFile, newFile).catch(helpers.error);

--- a/src/lib/openFolder.js
+++ b/src/lib/openFolder.js
@@ -1162,7 +1162,7 @@ async function refreshRenamedEntryInOpenFolders(
 ) {
 	if (!oldUrl || !newUrl || oldUrl === newUrl) return;
 
-	migrateOpenFolderStateUrls(oldUrl, newUrl);
+	migrateOpenFolderStateUrls(normalizeFolderUrl(oldUrl), normalizeFolderUrl(newUrl));
 
 	const isAncestorOrSame = (ancestor, descendant) => {
 		if (ancestor === descendant) return true;

--- a/src/lib/openFolder.js
+++ b/src/lib/openFolder.js
@@ -429,6 +429,7 @@ async function handleContextmenu(type, url, name, $target) {
  */
 function execOperation(type, action, url, $target, name) {
 	const { clipBoard, $node, remove, url: rootUrl } = openFolder.find(url);
+	const parentUrl = normalizeFolderUrl(Url.dirname(url));
 	const startLoading = () => $node.$title.classList.add("loading");
 	const stopLoading = () => $node.$title.classList.remove("loading");
 
@@ -441,7 +442,7 @@ function execOperation(type, action, url, $target, name) {
 			return deleteFile();
 
 		case "rename":
-			return renameFile();
+			return renameFile(parentUrl);
 
 		case "paste":
 			return paste();
@@ -626,7 +627,7 @@ function execOperation(type, action, url, $target, name) {
 		FileList.remove(url);
 	}
 
-	async function renameFile() {
+	async function renameFile(parentUrl) {
 		if (isTermuxSafUri(url) && !helpers.isFile(type)) {
 			alert(strings.warning, strings["rename not supported"]);
 			return;
@@ -666,7 +667,12 @@ function execOperation(type, action, url, $target, name) {
 		}
 
 		FileList.rename(url, newUrl);
-		await refreshRenamedEntryInOpenFolders(url, newUrl);
+		await refreshRenamedEntryInOpenFolders(
+			url,
+			newUrl,
+			parentUrl,
+			normalizeFolderUrl(Url.dirname(newUrl)),
+		);
 		toast(strings.success);
 	}
 
@@ -1058,10 +1064,26 @@ function appendEntryToOpenFolder(parentUrl, entryUrl, type) {
 }
 
 /**
+ * Normalize folder URLs for DOM/state lookup.
+ * Keeps roots intact while removing a trailing slash from non-root folders.
+ * @param {string} url
+ * @returns {string}
+ */
+function normalizeFolderUrl(url) {
+	if (!url) return url;
+	const { url: parsedUrl, query } = Url.parse(url);
+	if (parsedUrl.endsWith("/") && Url.pathname(parsedUrl) !== "/") {
+		return parsedUrl.slice(0, -1) + query;
+	}
+	return parsedUrl + query;
+}
+
+/**
  * Refresh matching expanded folder views.
  * @param {string} folderUrl
  */
 async function refreshOpenFolder(folderUrl) {
+	folderUrl = normalizeFolderUrl(folderUrl);
 	const filesApp = sidebarApps.get("files");
 	const $els = filesApp.getAll(`[data-url="${folderUrl}"]`);
 
@@ -1127,17 +1149,39 @@ function migrateOpenFolderStateUrls(oldUrl, newUrl) {
 }
 
 /**
- * Refresh the affected parent folders after a rename so FileTree state stays in sync with the filesystem.
+ * Refresh the minimal set of affected parent folders after a rename/move so FileTree state stays in sync with the filesystem.
+ * If an ancestor folder is already being refreshed, descendant folders are skipped because they will be rebuilt with the ancestor.
  * @param {string} oldUrl
  * @param {string} newUrl
  */
-async function refreshRenamedEntryInOpenFolders(oldUrl, newUrl) {
+async function refreshRenamedEntryInOpenFolders(
+	oldUrl,
+	newUrl,
+	oldParentUrl = normalizeFolderUrl(Url.dirname(oldUrl)),
+	newParentUrl = normalizeFolderUrl(Url.dirname(newUrl)),
+) {
 	if (!oldUrl || !newUrl || oldUrl === newUrl) return;
 
 	migrateOpenFolderStateUrls(oldUrl, newUrl);
 
-	const parentUrls = new Set([Url.dirname(oldUrl), Url.dirname(newUrl)]);
-	await Promise.all(Array.from(parentUrls).map(refreshOpenFolder));
+	const isAncestorOrSame = (ancestor, descendant) => {
+		if (ancestor === descendant) return true;
+		return descendant.startsWith(`${ancestor}/`);
+	};
+
+	const parentUrls = Array.from(
+		new Set([oldParentUrl, newParentUrl].map(normalizeFolderUrl)),
+	)
+		.filter(Boolean)
+		.filter((parentUrl, index, allParentUrls) => {
+			return !allParentUrls.some((otherUrl, otherIndex) => {
+				return (
+					otherIndex !== index && isAncestorOrSame(otherUrl, parentUrl)
+				);
+			});
+		});
+
+	await Promise.all(parentUrls.map(refreshOpenFolder));
 }
 
 /**


### PR DESCRIPTION
 ### Changes made

 #### 1. renameFile() no longer updates only DOM

 Before:
 - manually updated $target.dataset.url
 - manually updated $target.dataset.name
 - manually updated text/icon
 - for folders, collapsed/expanded the clicked node

 Now:
 - updates active editor file URIs as needed
 - updates FileList
 - refreshes affected open folder trees from filesystem via:
     - refreshRenamedEntryInOpenFolders(...)

-----

 #### 2. openFolder.renameItem() now refreshes tree state

 Before:
 - updated DOM nodes found by [data-url="${oldFile}"]
 - changed text/icon/dataset directly
 - tried collapse/expand for dirs

 Now:
 - updates FileList
 - updates active file URIs
 - calls:
     - refreshRenamedEntryInOpenFolders(oldFile, newFile)

 This fixes stale FileTree.entries.

 -----

 #### 3. Added normalizeFolderUrl(url)

 New helper in src/lib/openFolder.js

 Purpose:
 - remove trailing slash from non-root folder URLs
 - keep root / intact
 - make DOM lookups and refresh target matching consistent

 Used before:
 - parent folder refresh lookups
 - parent URL comparisons

-----

 #### 4. execOperation() now captures parent URL once

 Added:

 ```js
   const parentUrl = normalizeFolderUrl(Url.dirname(url));
 ```

 And rename now calls:

 ```js
   return renameFile(parentUrl);
 ```

 So rename uses the already-known parent instead of recomputing only later.

 ----

 #### 5. Added migrateOpenFolderStateUrls(oldUrl, newUrl)

 New helper in src/lib/openFolder.js

 Purpose:
 - migrate listState expansion keys when a folder URL changes
 - also updates descendant expansion keys

 Example:
 - /Root/Test
 - /Root/Test/child

 becomes:
 - /Root/NewTest
 - /Root/NewTest/child

 ----

 #### 6. Added refreshRenamedEntryInOpenFolders(...)

 New helper in src/lib/openFolder.js

 Purpose:
 - refresh affected parent folder trees after rename/move
 - re-sync FileTree with actual filesystem data

 Behavior:
 - accepts explicit old/new parent URLs
 - normalizes parent URLs
 - removes duplicate refreshes
 - skips descendant refresh if an ancestor is already being refreshed

 Example:
 - /Root/Test/t1.txt → /Root/t1.txt
 - refreshes /Root
 - skips /Root/Test

----

 #### 7. refreshOpenFolder(folderUrl) now normalizes URL first

 Before:
 - queried DOM using the raw passed folder URL

 Now:
 - normalizes folder URL first
 - improves exact [data-url="..."] matching when dirname() returns a trailing
   slash

 ----

 ### Net effect

 Rename now:
 - keeps FileList updated
 - keeps active editor URIs updated
 - refreshes the correct open folder tree(s) from FS
 - avoids stale FileTree.entries
 - avoids unnecessary duplicate/nested refreshes
 - preserves expanded folder state better across folder renames