### PR TITLE
fix(tabs): preserve active header during restore

### DIFF
--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -1796,7 +1796,9 @@ async function EditorManager($header, $body) {
 			: manager.files.length;
 		manager.files.splice(insertAt, 0, file);
 		syncOpenFileList();
-		$header.text = file.name;
+		if (!manager.activeFile) {
+			$header.text = file.name;
+		}
 		toggleProblemButton();
 	}
 


### PR DESCRIPTION
This was the issue : 👇
<img width="1080" height="367" alt="Screenshot_20260531-111613 Acode" src="https://github.com/user-attachments/assets/77654f46-79a9-40c2-9586-6cdbc9ac4363" />
