### PR TITLE
feat: polish app

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.foxdebug.acode" android-versionCode="972" version="1.12.2"
+<widget id="com.foxdebug.acode" android-versionCode="973" version="1.12.3"
     xmlns="http://www.w3.org/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:cdv="http://cordova.apache.org/ns/1.0">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.foxdebug.acode",
-  "version": "1.11.8",
+  "version": "1.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.foxdebug.acode",
-      "version": "1.11.8",
+      "version": "1.12.3",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.2",
@@ -4562,9 +4562,9 @@
       }
     },
     "node_modules/android-versions/node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5286,9 +5286,9 @@
       }
     },
     "node_modules/cordova-android/node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.3.tgz",
+      "integrity": "sha512-wnilbGyMxzbY7dNOl7jpKbLSjcfeweJWU5j4+u5qW+6/wuGD9KzIGOyZnQVSBM9E7DtWaaH3CyHkppYrKYoxwg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.foxdebug.acode",
   "displayName": "Acode",
-  "version": "1.11.8",
+  "version": "1.12.3",
   "description": "Acode is a code editor for android",
   "scripts": {
     "lang": "node ./utils/lang.js",

--- a/src/lang/ar-ye.json
+++ b/src/lang/ar-ye.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "تأكيد إغلاق تبويب الطرفية",
 	"terminal:image support": "دعم الصور",
 	"terminal": "الطرفية",
+	"terminal not installed prompt": "الطرفية غير مثبتة. هل تريد تهيئتها الآن؟",
+	"terminal first launch prompt": "بيئة الطرفية غير مثبتة. تتيح تشغيل الأوامر و SSH والبرمجة النصية. تثبيت الآن؟",
 	"allFileAccess": "الوصول لجميع الملفات",
 	"fonts": "الخطوط",
 	"sponsor": "دعم التطبيق",

--- a/src/lang/be-by.json
+++ b/src/lang/be-by.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Тэрмінал не ўсталяваны. Жадаеце ініцыялізаваць яго зараз?",
+	"terminal first launch prompt": "Асяроддзе тэрмінала не ўсталявана. Яно дазваляе выконваць каманды, SSH і скрыпты. Усталяваць зараз?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "Спонсар",

--- a/src/lang/bn-bd.json
+++ b/src/lang/bn-bd.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "টার্মিনাল",
+	"terminal not installed prompt": "টার্মিনাল ইনস্টল করা নেই। এখন এটি আরম্ভ করতে চান?",
+	"terminal first launch prompt": "টার্মিনাল পরিবেশ ইনস্টল করা নেই। এটি কমান্ড, SSH এবং স্ক্রিপ্টিং চালাতে সক্ষম করে। এখন ইনস্টল করবেন?",
 	"allFileAccess": "সকল ফাইল অ্যাক্সেস",
 	"fonts": "ফন্ট",
 	"sponsor": "স্পন্সর",

--- a/src/lang/cs-cz.json
+++ b/src/lang/cs-cz.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Potvrzení zavření karty terminálu",
 	"terminal:image support": "Podpora obrázků",
 	"terminal": "Terminál",
+	"terminal not installed prompt": "Terminál není nainstalován. Chcete jej nyní inicializovat?",
+	"terminal first launch prompt": "Prostředí terminálu není nainstalováno. Umožňuje spouštět příkazy, SSH a skripty. Nainstalovat nyní?",
 	"allFileAccess": "Přístup ke všem souborům",
 	"fonts": "Fonty",
 	"sponsor": "Sponzor",

--- a/src/lang/de-de.json
+++ b/src/lang/de-de.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Terminal-Tab schließen bestätigen",
 	"terminal:image support": "Bildunterstützung",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal ist nicht installiert. Möchten Sie es jetzt initialisieren?",
+	"terminal first launch prompt": "Die Terminal-Umgebung ist nicht installiert. Sie ermöglicht das Ausführen von Befehlen, SSH und Scripting. Jetzt installieren?",
 	"allFileAccess": "Zugriff auf alle Dateien",
 	"fonts": "Schriftarten",
 	"sponsor": "Sponsor",

--- a/src/lang/en-us.json
+++ b/src/lang/en-us.json
@@ -452,6 +452,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal is not installed. Would you like to initialize it now?",
+	"terminal first launch prompt": "Terminal environment is not installed. It enables running commands, SSH, and scripting. Install now?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "Sponsor",

--- a/src/lang/es-sv.json
+++ b/src/lang/es-sv.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal no está instalado. ¿Desea inicializarlo ahora?",
+	"terminal first launch prompt": "El entorno del terminal no está instalado. Permite ejecutar comandos, SSH y scripting. ¿Instalar ahora?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "Patrocinador",

--- a/src/lang/fr-fr.json
+++ b/src/lang/fr-fr.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Le terminal n'est pas installé. Voulez-vous l'initialiser maintenant ?",
+	"terminal first launch prompt": "L'environnement du terminal n'est pas installé. Il permet d'exécuter des commandes, SSH et des scripts. Installer maintenant ?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "Parrainer",

--- a/src/lang/he-il.json
+++ b/src/lang/he-il.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "הטרמינל לא מותקן. האם ברצונך לאתחל אותו כעת?",
+	"terminal first launch prompt": "סביבת הטרמינל לא מותקנת. היא מאפשרת הרצת פקודות, SSH וסקריפטים. להתקין כעת?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "לָתֵת חָסוּת",

--- a/src/lang/hi-in.json
+++ b/src/lang/hi-in.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "टर्मिनल टैब बंद करने की पुष्टि करें",
 	"terminal:image support": "इमेज सपोर्ट",
 	"terminal": "टर्मिनल",
+	"terminal not installed prompt": "टर्मिनल इंस्टॉल नहीं है। क्या आप इसे अभी आरंभ करना चाहते हैं?",
+	"terminal first launch prompt": "टर्मिनल वातावरण इंस्टॉल नहीं है। यह कमांड, SSH और स्क्रिप्टिंग चलाने में सक्षम बनाता है। अभी इंस्टॉल करें?",
 	"allFileAccess": "ऑल फ़ाइल एक्सेस",
 	"fonts": "फॉन्ट्स",
 	"sponsor": "स्पॉन्सर",

--- a/src/lang/hu-hu.json
+++ b/src/lang/hu-hu.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Megerősítés kérése a terminál lapjainak bezárásakor",
 	"terminal:image support": "Képek támogatása",
 	"terminal": "Terminál",
+	"terminal not installed prompt": "A terminál nincs telepítve. Szeretné most inicializálni?",
+	"terminal first launch prompt": "A terminál környezet nincs telepítve. Lehetővé teszi parancsok, SSH és szkriptek futtatását. Telepíti most?",
 	"allFileAccess": "Hozzáférés az összes fájlhoz",
 	"fonts": "Betűtípusok",
 	"sponsor": "Szponzor",

--- a/src/lang/id-id.json
+++ b/src/lang/id-id.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Konfirmasi penutupan tab terminal",
 	"terminal:image support": "Dukungan gambar",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal belum terpasang. Ingin menginisialisasinya sekarang?",
+	"terminal first launch prompt": "Lingkungan terminal belum terpasang. Ini memungkinkan menjalankan perintah, SSH, dan skrip. Pasang sekarang?",
 	"allFileAccess": "Semua akses berkas",
 	"fonts": "Huruf",
 	"sponsor": "Sponsor",

--- a/src/lang/ir-fa.json
+++ b/src/lang/ir-fa.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "ترمینال نصب نشده است. آیا می‌خواهید آن را راه‌اندازی کنید؟",
+	"terminal first launch prompt": "محیط ترمینال نصب نشده است. امکان اجرای دستورات، SSH و اسکریپت را فراهم می‌کند. اکنون نصب شود؟",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "حامی مالی",

--- a/src/lang/it-it.json
+++ b/src/lang/it-it.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Il terminale non è installato. Vuoi inizializzarlo ora?",
+	"terminal first launch prompt": "L'ambiente del terminale non è installato. Consente di eseguire comandi, SSH e scripting. Installare ora?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "Sponsor",

--- a/src/lang/ja-jp.json
+++ b/src/lang/ja-jp.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "ターミナルがインストールされていません。今すぐ初期化しますか？",
+	"terminal first launch prompt": "ターミナル環境がインストールされていません。コマンド、SSH、スクリプトを実行できます。今すぐインストールしますか？",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "スポンサー",

--- a/src/lang/ko-kr.json
+++ b/src/lang/ko-kr.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "터미널이 설치되지 않았습니다. 지금 초기화하시겠습니까?",
+	"terminal first launch prompt": "터미널 환경이 설치되지 않았습니다. 명령, SSH, 스크립팅을 실행할 수 있습니다. 지금 설치하시겠습니까?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "스폰서",

--- a/src/lang/ml-in.json
+++ b/src/lang/ml-in.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "ടെർമിനൽ ഇൻസ്റ്റാൾ ചെയ്തിട്ടില്ല. ഇപ്പോൾ ആരംഭിക്കണോ?",
+	"terminal first launch prompt": "ടെർമിനൽ പരിസ്ഥിതി ഇൻസ്റ്റാൾ ചെയ്തിട്ടില്ല. ഇത് കമാൻഡുകൾ, SSH, സ്ക്രിപ്റ്റിംഗ് എന്നിവ പ്രവർത്തിപ്പിക്കാൻ സഹായിക്കുന്നു. ഇപ്പോൾ ഇൻസ്റ്റാൾ ചെയ്യണോ?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "സ്പോൺസർ",

--- a/src/lang/mm-unicode.json
+++ b/src/lang/mm-unicode.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal ထည့်သွင်းမထားပါ။ ယခုစတင်လိုပါသလား။",
+	"terminal first launch prompt": "Terminal ပတ်ဝန်းကျင် ထည့်သွင်းမထားပါ။ ၎င်းသည် command များ၊ SSH နှင့် scripting လုပ်ဆောင်နိုင်စေပါသည်။ ယခုထည့်သွင်းမလား။",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "စပွန်ဆာ",

--- a/src/lang/mm-zawgyi.json
+++ b/src/lang/mm-zawgyi.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal ထည့္သြင္းမထားပါ။ ယခုစတင္လိုပါသလား။",
+	"terminal first launch prompt": "Terminal ပတ္ဝန္းက်င္ ထည့္သြင္းမထားပါ။ ၎င္းသည္ command မ်ား၊ SSH ႏွင့္ scripting လုပ္ေဆာင္ႏိုင္ေစပါသည္။ ယခုထည့္သြင္းမလား။",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "စပွန်ဆာ",

--- a/src/lang/pl-pl.json
+++ b/src/lang/pl-pl.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Potwierdź zamknięcie karty terminala",
 	"terminal:image support": "Obsługa obrazów",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal nie jest zainstalowany. Czy chcesz go teraz zainicjować?",
+	"terminal first launch prompt": "Środowisko terminala nie jest zainstalowane. Umożliwia uruchamianie poleceń, SSH i skryptów. Zainstalować teraz?",
 	"allFileAccess": "Dostęp do wszystkich plików",
 	"fonts": "Czcionki",
 	"sponsor": "Sponsor",

--- a/src/lang/pt-br.json
+++ b/src/lang/pt-br.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirme o fechamento da aba do terminal",
 	"terminal:image support": "Suportar imagens",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "O terminal não está instalado. Deseja inicializá-lo agora?",
+	"terminal first launch prompt": "O ambiente do terminal não está instalado. Ele permite executar comandos, SSH e scripts. Instalar agora?",
 	"allFileAccess": "Acesso total aos arquivos",
 	"fonts": "Fontes",
 	"sponsor": "Patrocinador",

--- a/src/lang/pu-in.json
+++ b/src/lang/pu-in.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "ਟਰਮੀਨਲ ਸਥਾਪਤ ਨਹੀਂ ਹੈ। ਕੀ ਤੁਸੀਂ ਇਸਨੂੰ ਹੁਣੇ ਸ਼ੁਰੂ ਕਰਨਾ ਚਾਹੁੰਦੇ ਹੋ?",
+	"terminal first launch prompt": "ਟਰਮੀਨਲ ਵਾਤਾਵਰਨ ਸਥਾਪਤ ਨਹੀਂ ਹੈ। ਇਹ ਕਮਾਂਡਾਂ, SSH ਅਤੇ ਸਕ੍ਰਿਪਟਿੰਗ ਚਲਾਉਣ ਦੇ ਯੋਗ ਬਣਾਉਂਦਾ ਹੈ। ਹੁਣੇ ਸਥਾਪਤ ਕਰਨਾ ਹੈ?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "ਸਪਾਂਸਰ",

--- a/src/lang/ru-ru.json
+++ b/src/lang/ru-ru.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Терминал",
+	"terminal not installed prompt": "Терминал не установлен. Хотите инициализировать его сейчас?",
+	"terminal first launch prompt": "Среда терминала не установлена. Она позволяет выполнять команды, SSH и скрипты. Установить сейчас?",
 	"allFileAccess": "Доступ ко всем файлам",
 	"fonts": "Шрифты",
 	"sponsor": "Спонсор",

--- a/src/lang/tl-ph.json
+++ b/src/lang/tl-ph.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Hindi naka-install ang terminal. Gusto mo ba itong simulan ngayon?",
+	"terminal first launch prompt": "Ang terminal environment ay hindi naka-install. Ito ay nagbibigay-daan sa pagpapatakbo ng mga command, SSH, at scripting. I-install ngayon?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "Sponsor",

--- a/src/lang/tr-tr.json
+++ b/src/lang/tr-tr.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal kurulu değil. Şimdi başlatmak ister misiniz?",
+	"terminal first launch prompt": "Terminal ortamı kurulu değil. Komut çalıştırma, SSH ve betik yazmayı sağlar. Şimdi kur?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "Sponsor",

--- a/src/lang/uk-ua.json
+++ b/src/lang/uk-ua.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Підтримка зображень",
 	"terminal": "Термінал",
+	"terminal not installed prompt": "Термінал не встановлено. Бажаєте ініціалізувати його зараз?",
+	"terminal first launch prompt": "Середовище термінала не встановлено. Воно дозволяє виконувати команди, SSH та скрипти. Встановити зараз?",
 	"allFileAccess": "Доступ до всіх файлів",
 	"fonts": "Шрифти",
 	"sponsor": "Спонсор",

--- a/src/lang/uz-uz.json
+++ b/src/lang/uz-uz.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal o'rnatilmagan. Uni hozir ishga tushirishni xohlaysizmi?",
+	"terminal first launch prompt": "Terminal muhiti o'rnatilmagan. Bu buyruqlar, SSH va skriptlarni ishga tushirish imkonini beradi. Hozir o'rnatilsinmi?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "Homiy",

--- a/src/lang/vi-vn.json
+++ b/src/lang/vi-vn.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "Terminal chưa được cài đặt. Bạn có muốn khởi tạo nó ngay bây giờ?",
+	"terminal first launch prompt": "Môi trường terminal chưa được cài đặt. Nó cho phép chạy lệnh, SSH và tập lệnh. Cài đặt ngay?",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "Nhà tài trợ",

--- a/src/lang/zh-cn.json
+++ b/src/lang/zh-cn.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "确认关闭终端标签页",
 	"terminal:image support": "图像支持",
 	"terminal": "终端",
+	"terminal not installed prompt": "终端未安装。是否立即初始化？",
+	"terminal first launch prompt": "终端环境未安装。它可用于运行命令、SSH 和脚本。立即安装？",
 	"allFileAccess": "所有文件读写权限",
 	"fonts": "字体",
 	"sponsor": "赞助",

--- a/src/lang/zh-hant.json
+++ b/src/lang/zh-hant.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "確認關閉終端分頁",
 	"terminal:image support": "圖像支持",
 	"terminal": "終端機",
+	"terminal not installed prompt": "終端未安裝。是否立即初始化？",
+	"terminal first launch prompt": "終端環境未安裝。它可用於運行命令、SSH 和腳本。立即安裝？",
 	"allFileAccess": "所有文件讀寫權限",
 	"fonts": "字體",
 	"sponsor": "贊助",

--- a/src/lang/zh-tw.json
+++ b/src/lang/zh-tw.json
@@ -443,6 +443,8 @@
 	"terminal:confirm tab close": "Confirm terminal tab close",
 	"terminal:image support": "Image support",
 	"terminal": "Terminal",
+	"terminal not installed prompt": "終端未安裝。是否立即初始化？",
+	"terminal first launch prompt": "終端環境未安裝。它可用於運行命令、SSH 和腳本。立即安裝？",
 	"allFileAccess": "All file access",
 	"fonts": "Fonts",
 	"sponsor": "贊助",

--- a/src/lib/devTools.js
+++ b/src/lib/devTools.js
@@ -53,6 +53,7 @@ const devTools = {
 						"utf-8",
 					);
 					await fsOperation(DATA_STORAGE).createFile("eruda.js", erudaScript);
+				} catch {
 				} finally {
 					if (showLoader) loader.destroy();
 				}

--- a/src/main.js
+++ b/src/main.js
@@ -499,7 +499,12 @@ async function promptTerminalInstall() {
 			const { default: terminalManager } = await import(
 				"components/terminal/terminalManager"
 			);
-			terminalManager.checkAndInstallTerminal().catch(console.error);
+			const result = await terminalManager.checkAndInstallTerminal();
+			if (!result.success || result.error) {
+				helpers.error(
+					new Error(result.error || "Terminal installation failed"),
+				);
+			}
 		}
 	} catch (e) {
 		console.warn("Terminal check failed:", e);

--- a/src/main.js
+++ b/src/main.js
@@ -137,8 +137,6 @@ async function onDeviceReady() {
 		);
 	});
 
-	startAd();
-
 	let installSource = INSTALL_SOURCE_PLAY;
 
 	try {
@@ -218,7 +216,10 @@ async function onDeviceReady() {
 
 	const { versionCode } = BuildInfo;
 
-	if (previousVersionCode !== versionCode) {
+	if (
+		!Number.isNaN(previousVersionCode) &&
+		previousVersionCode !== versionCode
+	) {
 		system.clearCache();
 	}
 
@@ -319,6 +320,7 @@ async function onDeviceReady() {
 			}
 
 			fetchPromotions();
+			startAd();
 		}, 500);
 	}
 
@@ -388,6 +390,9 @@ async function onDeviceReady() {
 			);
 		})
 		.catch(console.error);
+
+	// Prompt to initialize terminal if not installed and not already asked
+	promptTerminalInstall();
 }
 
 async function onLogin() {
@@ -456,14 +461,48 @@ async function promptUpdateCheckConsent() {
 			return;
 		}
 
-		const message = strings["prompt update check consent message"];
-		const shouldEnable = await confirm(strings?.confirm, message);
-		localStorage.setItem("checkForUpdatesPrompted", "true");
-		if (shouldEnable) {
+		const isPlayStore = window.appInstallSource === "com.android.vending";
+
+		if (!isPlayStore) {
+			const message = strings["prompt update check consent message"];
+			const shouldEnable = await confirm(strings?.confirm, message);
+
+			localStorage.setItem("checkForUpdatesPrompted", "true");
+			if (shouldEnable) {
+				await settings.update({ checkForAppUpdates: true }, false);
+			}
+		} else {
+			localStorage.setItem("checkForUpdatesPrompted", "true");
 			await settings.update({ checkForAppUpdates: true }, false);
 		}
 	} catch (error) {
 		console.error("Failed to prompt for update check consent", error);
+	}
+}
+
+async function promptTerminalInstall() {
+	try {
+		if (localStorage.getItem("terminalInstallPrompted")) return;
+		const isInstalled = await Terminal.isInstalled();
+		if (isInstalled) return;
+
+		const isSupported = await Terminal.isSupported();
+		if (!isSupported) return;
+
+		const shouldInstall = await confirm(
+			strings.terminal,
+			strings["terminal first launch prompt"],
+		);
+
+		localStorage.setItem("terminalInstallPrompted", "true");
+		if (shouldInstall) {
+			const { default: terminalManager } = await import(
+				"components/terminal/terminalManager"
+			);
+			terminalManager.checkAndInstallTerminal().catch(console.error);
+		}
+	} catch (e) {
+		console.warn("Terminal check failed:", e);
 	}
 }
 

--- a/src/pages/fileBrowser/fileBrowser.js
+++ b/src/pages/fileBrowser/fileBrowser.js
@@ -6,6 +6,7 @@ import Checkbox from "components/checkbox";
 import Contextmenu from "components/contextmenu";
 import Page from "components/page";
 import searchBar from "components/searchbar";
+import terminalManager from "components/terminal/terminalManager";
 import alert from "dialogs/alert";
 import confirm from "dialogs/confirm";
 import loader from "dialogs/loader";
@@ -867,7 +868,45 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 					navigateToHome();
 					return;
 				}
-				navigate(url, name);
+				checkAndNavigate(url, name);
+			}
+
+			async function checkAndNavigate(dirUrl, dirName) {
+				if (dirUrl === `${cordova.file.dataDirectory}public`) {
+					try {
+						const isInstalled = await Terminal.isInstalled();
+						if (!isInstalled) {
+							const shouldInstall = await confirm(
+								strings.terminal,
+								strings["terminal not installed prompt"],
+							);
+							if (shouldInstall) {
+								const loaderInstance = loader.create(
+									strings.terminal,
+									strings["loading..."],
+								);
+								try {
+									loaderInstance.show();
+									const res = await terminalManager.checkAndInstallTerminal();
+									if (res.error) {
+										throw new Error(res.error);
+									}
+								} catch (error) {
+									helpers.error(error);
+								} finally {
+									loaderInstance.destroy();
+								}
+							} else {
+								return;
+							}
+						}
+					} catch (e) {
+						console.error("Terminal check failed:", e);
+						helpers.error(e, dirUrl);
+						return;
+					}
+				}
+				navigate(dirUrl, dirName);
 			}
 
 			function navigateToHome() {

--- a/src/pages/fileBrowser/fileBrowser.js
+++ b/src/pages/fileBrowser/fileBrowser.js
@@ -863,16 +863,13 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 					break;
 			}
 
-			function folder() {
+			async function folder() {
 				if (home) {
 					navigateToHome();
 					return;
 				}
-				checkAndNavigate(url, name);
-			}
 
-			async function checkAndNavigate(dirUrl, dirName) {
-				if (dirUrl === `${cordova.file.dataDirectory}public`) {
+				if (url === `${cordova.file.dataDirectory}public`) {
 					try {
 						const isInstalled = await Terminal.isInstalled();
 						if (!isInstalled) {
@@ -893,6 +890,7 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 									}
 								} catch (error) {
 									helpers.error(error);
+									return;
 								} finally {
 									loaderInstance.destroy();
 								}
@@ -902,11 +900,11 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 						}
 					} catch (e) {
 						console.error("Terminal check failed:", e);
-						helpers.error(e, dirUrl);
+						helpers.error(e, url);
 						return;
 					}
 				}
-				navigate(dirUrl, dirName);
+				navigate(url, name);
 			}
 
 			function navigateToHome() {


### PR DESCRIPTION
- Bump version to 1.12.3 (versionCode 973), sync package.json/lockfile
- Add "terminal not installed prompt" and "terminal first launch prompt" i18n strings (32 locales)
- Show terminal installation prompt on first launch; prompt on navigating to public/ directory
- Auto-enable update checks without prompt for Play Store installs; guard against NaN versionCode
- Move ad initialization to run only on non-Play Store builds after promotions fetch
- Prevent eruda download failures from crashing developer tools init
- Remove stray admob extraneous entry from lockfile