### PR TITLE
fix(terminal): handle axs symlink runtime checks

### DIFF
--- a/src/plugins/system/android/com/foxdebug/system/System.java
+++ b/src/plugins/system/android/com/foxdebug/system/System.java
@@ -1015,30 +1015,20 @@ public class System extends CordovaPlugin {
     }
 
     public boolean fileExists(String path, String countSymlinks) {
-        boolean followSymlinks = !Boolean.parseBoolean(countSymlinks);
+        boolean countSymbolicLinks = Boolean.parseBoolean(countSymlinks);
         File file = new File(path);
 
         // Android < O does not implement File#toPath(), fall back to legacy checks
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            if (!file.exists()) return false;
-            if (followSymlinks) {
-                try {
-                    // If canonical and absolute paths differ, it's a symlink
-                    return file.getCanonicalPath().equals(file.getAbsolutePath());
-                } catch (IOException ignored) {
-                    return false;
-                }
-            }
-            return true;
+            return file.exists();
         }
 
         Path p = file.toPath();
         try {
-            if (followSymlinks) {
-                return Files.exists(p) && !Files.isSymbolicLink(p);
-            } else {
+            if (countSymbolicLinks) {
                 return Files.exists(p, LinkOption.NOFOLLOW_LINKS);
             }
+            return Files.exists(p);
         } catch (Exception e) {
             return false;
         }

--- a/src/plugins/terminal/src/android/ProcessManager.java
+++ b/src/plugins/terminal/src/android/ProcessManager.java
@@ -5,6 +5,9 @@ import android.content.pm.PackageManager;
 import java.io.*;
 import java.util.Map;
 import java.util.TimeZone;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import com.foxdebug.acode.rk.exec.terminal.*;
 
 public class ProcessManager {
@@ -19,10 +22,55 @@ public class ProcessManager {
      * Creates a ProcessBuilder with common environment setup
      */
     public ProcessBuilder createProcessBuilder(String cmd, boolean useAlpine) {
+        if (useAlpine) {
+            refreshAxsSymlink();
+        }
         String xcmd = useAlpine ? "source $PREFIX/init-sandbox.sh " + cmd : cmd;
         ProcessBuilder builder = new ProcessBuilder("sh", "-c", xcmd);
         setupEnvironment(builder.environment());
         return builder;
+    }
+
+    /**
+     * Play Store builds package axs as a native library. Keep the legacy
+     * $PREFIX/axs path valid for scripts and plugins that execute it directly.
+     */
+    private void refreshAxsSymlink() {
+        if (isFdroidBuild()) {
+            return;
+        }
+
+        Path axsPath = Paths.get(context.getFilesDir().getAbsolutePath(), "axs");
+        Path nativeAxsPath = Paths.get(context.getApplicationInfo().nativeLibraryDir, "libaxs.so");
+
+        if (!Files.exists(nativeAxsPath)) {
+            return;
+        }
+
+        try {
+            if (Files.isSymbolicLink(axsPath)) {
+                Path currentTarget = Files.readSymbolicLink(axsPath);
+                if (currentTarget.equals(nativeAxsPath)) {
+                    return;
+                }
+            }
+
+            Files.deleteIfExists(axsPath);
+            Files.createSymbolicLink(axsPath, nativeAxsPath);
+        } catch (Exception ignored) {
+            // init-sandbox.sh will surface the execution error if the link is unusable.
+        }
+    }
+
+    private boolean isFdroidBuild() {
+        try {
+            int target = context.getPackageManager()
+                .getPackageInfo(context.getPackageName(), 0)
+                .applicationInfo.targetSdkVersion;
+            return target <= 28;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
     }
     
     /**

--- a/src/plugins/terminal/src/android/ProcessManager.java
+++ b/src/plugins/terminal/src/android/ProcessManager.java
@@ -2,6 +2,7 @@ package com.foxdebug.acode.rk.exec.terminal;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import java.io.*;
 import java.util.Map;
 import java.util.TimeZone;
@@ -36,7 +37,7 @@ public class ProcessManager {
      * $PREFIX/axs path valid for scripts and plugins that execute it directly.
      */
     private void refreshAxsSymlink() {
-        if (isFdroidBuild()) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O || isFdroidBuild()) {
             return;
         }
 
@@ -63,13 +64,18 @@ public class ProcessManager {
     }
 
     private boolean isFdroidBuild() {
+        // F-Droid builds are intentionally pinned to targetSdkVersion 28.
+        // This convention is also exposed to scripts through the FDROID env var.
+        return getTargetSdkVersion() <= 28;
+    }
+
+    private int getTargetSdkVersion() {
         try {
-            int target = context.getPackageManager()
+            return context.getPackageManager()
                 .getPackageInfo(context.getPackageName(), 0)
                 .applicationInfo.targetSdkVersion;
-            return target <= 28;
         } catch (PackageManager.NameNotFoundException e) {
-            return false;
+            return Build.VERSION_CODES.P;
         }
     }
     
@@ -83,14 +89,7 @@ public class ProcessManager {
         TimeZone tz = TimeZone.getDefault();
         env.put("ANDROID_TZ", tz.getID());
         
-        try {
-            int target = context.getPackageManager()
-                .getPackageInfo(context.getPackageName(), 0)
-                .applicationInfo.targetSdkVersion;
-            env.put("FDROID", String.valueOf(target <= 28));
-        } catch (PackageManager.NameNotFoundException e) {
-            e.printStackTrace();
-        }
+        env.put("FDROID", String.valueOf(isFdroidBuild()));
     }
     
     /**


### PR DESCRIPTION
Update `system.fileExists` so normal checks follow valid symlinks while still allowing callers to count symlink entries explicitly.

Refresh the packaged Play Store axs symlink before Alpine-backed executor commands so LSP and plugin flows can resolve `$PREFIX/axs` without requiring a terminal tab to repair it first.