### PR TITLE
Refactor boot script and add editor interaction handler

### DIFF
--- a/src/boot.js
+++ b/src/boot.js
@@ -3,66 +3,67 @@
 // main.js is never imported directly; it's loaded dynamically so the dev server
 // can serve a freshly compiled version on every reload.
 
-const DEV_MODE = typeof __DEV_MODE__ !== 'undefined' && __DEV_MODE__;
-const DEV_HOST = typeof __DEV_HOST__ !== 'undefined' ? __DEV_HOST__ : '';
-const DEV_PORT = typeof __DEV_PORT__ !== 'undefined' ? __DEV_PORT__ : '';
-const DEV_PROTO = typeof __DEV_PROTO__ !== 'undefined' ? __DEV_PROTO__ : '';
-const DEV_ORIGIN = DEV_HOST && DEV_PORT && DEV_PROTO
-  ? `${DEV_PROTO}://${DEV_HOST}:${DEV_PORT}`
-  : '';
+const DEV_MODE = typeof __DEV_MODE__ !== "undefined" && __DEV_MODE__;
+const DEV_HOST = typeof __DEV_HOST__ !== "undefined" ? __DEV_HOST__ : "";
+const DEV_PORT = typeof __DEV_PORT__ !== "undefined" ? __DEV_PORT__ : "";
+const DEV_PROTO = typeof __DEV_PROTO__ !== "undefined" ? __DEV_PROTO__ : "";
+const DEV_ORIGIN =
+	DEV_HOST && DEV_PORT && DEV_PROTO
+		? `${DEV_PROTO}://${DEV_HOST}:${DEV_PORT}`
+		: "";
 
 const loadScript = (src) => {
-  const el = document.createElement('script');
-  el.src = src;
-  document.head.appendChild(el);
+	const el = document.createElement("script");
+	el.src = src;
+	document.head.appendChild(el);
 };
 
 const loadCSS = (href) => {
-  const el = document.createElement('link');
-  el.rel = 'stylesheet';
-  el.href = href;
-  document.head.appendChild(el);
+	const el = document.createElement("link");
+	el.rel = "stylesheet";
+	el.href = href;
+	document.head.appendChild(el);
 };
 
 const bootDev = () => {
-  loadCSS(`${DEV_ORIGIN}/build/main.css`);
-  loadScript(`${DEV_ORIGIN}/build/main.js`);
+	loadCSS(`${DEV_ORIGIN}/build/main.css`);
+	loadScript(`${DEV_ORIGIN}/build/main.js`);
 
-  const wsProto = DEV_PROTO === 'https' ? 'wss' : 'ws';
-  const connectWS = () => {
-    let ws;
-    try {
-      ws = new WebSocket(`${wsProto}://${DEV_HOST}:${DEV_PORT}`);
-    } catch {
-      setTimeout(connectWS, 1000);
-      return;
-    }
-    ws.onmessage = ({ data }) => {
-      if (data === 'reload') location.reload();
-    };
-    ws.onclose = () => setTimeout(connectWS, 1000);
-    ws.onerror = () => {};
-  };
-  connectWS();
+	const wsProto = DEV_PROTO === "https" ? "wss" : "ws";
+	const connectWS = () => {
+		let ws;
+		try {
+			ws = new WebSocket(`${wsProto}://${DEV_HOST}:${DEV_PORT}`);
+		} catch {
+			setTimeout(connectWS, 1000);
+			return;
+		}
+		ws.onmessage = ({ data }) => {
+			if (data === "reload") location.reload();
+		};
+		ws.onclose = () => setTimeout(connectWS, 1000);
+		ws.onerror = () => {};
+	};
+	connectWS();
 };
 
 const bootProd = () => {
-  loadCSS('./build/main.css');
-  loadScript('./build/main.js');
+	loadCSS("./build/main.css");
+	loadScript("./build/main.js");
 };
 
 if (DEV_MODE && DEV_ORIGIN) {
-  fetch(`${DEV_ORIGIN}/build/main.js`, { method: 'HEAD' })
-    .then((res) => {
-      if (res.ok) {
-        bootDev();
-      } else {
-        bootProd();
-      }
-    })
-    .catch(() => {
-      bootProd();
-    });
+	fetch(`${DEV_ORIGIN}/build/main.js`, { method: "HEAD" })
+		.then((res) => {
+			if (res.ok) {
+				bootDev();
+			} else {
+				bootProd();
+			}
+		})
+		.catch(() => {
+			bootProd();
+		});
 } else {
-  bootProd();
+	bootProd();
 }

--- a/src/boot.js
+++ b/src/boot.js
@@ -3,65 +3,66 @@
 // main.js is never imported directly; it's loaded dynamically so the dev server
 // can serve a freshly compiled version on every reload.
 
-(function boot() {
-	"use strict";
+const DEV_MODE = typeof __DEV_MODE__ !== 'undefined' && __DEV_MODE__;
+const DEV_HOST = typeof __DEV_HOST__ !== 'undefined' ? __DEV_HOST__ : '';
+const DEV_PORT = typeof __DEV_PORT__ !== 'undefined' ? __DEV_PORT__ : '';
+const DEV_PROTO = typeof __DEV_PROTO__ !== 'undefined' ? __DEV_PROTO__ : '';
+const DEV_ORIGIN = DEV_HOST && DEV_PORT && DEV_PROTO
+  ? `${DEV_PROTO}://${DEV_HOST}:${DEV_PORT}`
+  : '';
 
-	var DEV_MODE = typeof __DEV_MODE__ !== "undefined" && __DEV_MODE__;
-	var DEV_HOST = typeof __DEV_HOST__ !== "undefined" ? __DEV_HOST__ : "";
-	var DEV_PORT = typeof __DEV_PORT__ !== "undefined" ? __DEV_PORT__ : "";
-	var DEV_PROTO = typeof __DEV_PROTO__ !== "undefined" ? __DEV_PROTO__ : "";
-	var DEV_ORIGIN =
-		DEV_HOST && DEV_PORT && DEV_PROTO
-			? DEV_PROTO.concat("://", DEV_HOST, ":", DEV_PORT)
-			: "";
+const loadScript = (src) => {
+  const el = document.createElement('script');
+  el.src = src;
+  document.head.appendChild(el);
+};
 
-	function loadScript(src) {
-		var script = document.createElement("script");
-		script.src = src;
-		document.head.appendChild(script);
-	}
+const loadCSS = (href) => {
+  const el = document.createElement('link');
+  el.rel = 'stylesheet';
+  el.href = href;
+  document.head.appendChild(el);
+};
 
-	function loadCSS(href) {
-		var link = document.createElement("link");
-		link.rel = "stylesheet";
-		link.href = href;
-		document.head.appendChild(link);
-	}
+const bootDev = () => {
+  loadCSS(`${DEV_ORIGIN}/build/main.css`);
+  loadScript(`${DEV_ORIGIN}/build/main.js`);
 
-	if (DEV_MODE && DEV_ORIGIN) {
-		// --- Development mode: load everything from the dev server ---
-		loadCSS("".concat(DEV_ORIGIN, "/build/main.css"));
-		loadScript("".concat(DEV_ORIGIN, "/build/main.js"));
+  const wsProto = DEV_PROTO === 'https' ? 'wss' : 'ws';
+  const connectWS = () => {
+    let ws;
+    try {
+      ws = new WebSocket(`${wsProto}://${DEV_HOST}:${DEV_PORT}`);
+    } catch {
+      setTimeout(connectWS, 1000);
+      return;
+    }
+    ws.onmessage = ({ data }) => {
+      if (data === 'reload') location.reload();
+    };
+    ws.onclose = () => setTimeout(connectWS, 1000);
+    ws.onerror = () => {};
+  };
+  connectWS();
+};
 
-		// WebSocket reload channel
-		(function connectWS() {
-			var wsProto = DEV_PROTO === "https" ? "wss" : "ws";
-			var ws;
+const bootProd = () => {
+  loadCSS('./build/main.css');
+  loadScript('./build/main.js');
+};
 
-			try {
-				ws = new WebSocket("".concat(wsProto, "://", DEV_HOST, ":", DEV_PORT));
-			} catch (_e) {
-				setTimeout(connectWS, 1000);
-				return;
-			}
-
-			ws.onmessage = function (e) {
-				if (e.data === "reload") {
-					window.location.reload();
-				}
-			};
-
-			ws.onclose = function () {
-				setTimeout(connectWS, 1000);
-			};
-
-			ws.onerror = function () {
-				// Will trigger onclose and retry
-			};
-		})();
-	} else {
-		// --- Production / fallback: load local bundle ---
-		loadCSS("./build/main.css");
-		loadScript("./build/main.js");
-	}
-})();
+if (DEV_MODE && DEV_ORIGIN) {
+  fetch(`${DEV_ORIGIN}/build/main.js`, { method: 'HEAD' })
+    .then((res) => {
+      if (res.ok) {
+        bootDev();
+      } else {
+        bootProd();
+      }
+    })
+    .catch(() => {
+      bootProd();
+    });
+} else {
+  bootProd();
+}

--- a/src/boot.js
+++ b/src/boot.js
@@ -53,7 +53,7 @@ const bootProd = () => {
 };
 
 if (DEV_MODE && DEV_ORIGIN) {
-	fetch(`${DEV_ORIGIN}/build/main.js`, { method: "HEAD" })
+	fetch(`${DEV_ORIGIN}/build/main.js`, { method: "HEAD", cache: "no-store" })
 		.then((res) => {
 			if (res.ok) {
 				bootDev();

--- a/src/handlers/editorWorkaround.js
+++ b/src/handlers/editorWorkaround.js
@@ -28,7 +28,7 @@ document.addEventListener("keydown", () => {
 });
 
 document.addEventListener("selectionchange", () => {
-	if (lastInput === "keyboard") return;
+	if (lastInput !== "pointer") return;
 	const sel = document.getSelection();
 	if (!sel?.rangeCount) return;
 	const node = sel.getRangeAt(0).startContainer;

--- a/src/handlers/editorWorkaround.js
+++ b/src/handlers/editorWorkaround.js
@@ -1,0 +1,34 @@
+let debounceTimer;
+let lastInput = null;
+let keyboardTimer;
+
+function setTouched() {
+	clearTimeout(debounceTimer);
+	document.body.setAttribute("data-editor-touched", "true");
+	debounceTimer = setTimeout(() => {
+		document.body.removeAttribute("data-editor-touched");
+	}, 200);
+}
+
+document.addEventListener("pointerdown", (e) => {
+	lastInput = "pointer";
+	if (e.target.closest(".editor-container")) setTouched();
+}, true);
+
+document.addEventListener("keydown", () => {
+	lastInput = "keyboard";
+	clearTimeout(keyboardTimer);
+	keyboardTimer = setTimeout(() => {
+		lastInput = null;
+	}, 500);
+});
+
+document.addEventListener("selectionchange", () => {
+	if (lastInput === "keyboard") return;
+	const sel = document.getSelection();
+	if (!sel?.rangeCount) return;
+	const node = sel.getRangeAt(0).startContainer;
+	if (!node) return;
+	const el = node.nodeType === 3 ? node.parentElement : node;
+	if (el?.closest(".editor-container")) setTouched();
+});

--- a/src/handlers/editorWorkaround.js
+++ b/src/handlers/editorWorkaround.js
@@ -10,10 +10,14 @@ function setTouched() {
 	}, 200);
 }
 
-document.addEventListener("pointerdown", (e) => {
-	lastInput = "pointer";
-	if (e.target.closest(".editor-container")) setTouched();
-}, true);
+document.addEventListener(
+	"pointerdown",
+	(e) => {
+		lastInput = "pointer";
+		if (e.target.closest(".editor-container")) setTouched();
+	},
+	true,
+);
 
 document.addEventListener("keydown", () => {
 	lastInput = "keyboard";

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import "styles/wideScreen.scss";
 import "lib/polyfill";
 import "cm/supportedModes";
 import "components/WebComponents";
+import "handlers/editorWorkaround";
 
 import fsOperation from "fileSystem";
 import sidebarApps from "sidebarApps";

--- a/src/main.scss
+++ b/src/main.scss
@@ -81,6 +81,16 @@ body {
     }
   }
 
+  &[data-editor-touched] {
+    #quick-tools {
+      pointer-events: none;
+    }
+
+    #lsp-status-bar {
+      pointer-events: none;
+    }
+  }
+
   .main {
     position: relative;
   }
@@ -793,9 +803,14 @@ input[type="search"]::-webkit-search-results-decoration {
   }
 
   @supports not (gap: 1px) {
-    > * + * { margin-top: 8px; }
+    >*+* {
+      margin-top: 8px;
+    }
+
     .notification-toast {
-      > * + * { margin-left: 12px; }
+      >*+* {
+        margin-left: 12px;
+      }
     }
   }
 


### PR DESCRIPTION
Refactor boot script and add editor interaction handler
- src/boot.js: Modernized with const, arrow functions, and template literals. Added a fetch HEAD health check to the dev server before booting dev mode, falling back to production if unreachable. WebSocket reload logic extracted into connectWS().
- src/handlers/editorWorkaround.js (new): Tracks pointer vs. keyboard input state via pointerdown, keydown, and selectionchange events. Temporarily sets data-editor-touched on <body> during pointer-based editor interactions, with a 200ms debounce. Keyboard-driven selections are ignored to avoid spurious triggers.
- src/main.js: Imported editorWorkaround handler as a side-effect module.
- src/main.scss: Added body[data-editor-touched] rule that sets pointer-events: none on #quick-tools and #lsp-status-bar, preventing accidental toolbar clicks during editor touch/pointer operations.