### PR TITLE
feat(terminal): add terminal theme picker to Theme Settings page

### DIFF
--- a/src/pages/themeSetting/themeSetting.js
+++ b/src/pages/themeSetting/themeSetting.js
@@ -8,6 +8,7 @@ import { basicSetup, EditorView } from "codemirror";
 import Page from "components/page";
 import searchBar from "components/searchbar";
 import TabView from "components/tabView";
+import { TerminalThemeManager } from "components/terminal";
 import alert from "dialogs/alert";
 import Ref from "html-tag-js/ref";
 import actionStack from "lib/actionStack";
@@ -16,6 +17,7 @@ import removeAds from "lib/removeAds";
 import appSettings from "lib/settings";
 import { hideAd } from "lib/startAd";
 import CustomTheme from "pages/customTheme";
+import { updateActiveTerminals } from "settings/terminalSettings";
 import ThemeBuilder from "theme/builder";
 import themes from "theme/list";
 import helpers from "utils/helpers";
@@ -46,6 +48,7 @@ export default function () {
 
 	function createPreview(themeId) {
 		destroyPreview("create");
+		$themePreview.innerHTML = "";
 		const theme = getThemeExtensions(themeId, [oneDark]);
 		const fixedHeightTheme = EditorView.theme({
 			"&": { height: "100%", flex: "1 1 auto" },
@@ -81,6 +84,9 @@ export default function () {
 				</span>
 				<span onclick={renderEditorThemes} tabindex={0}>
 					Editor
+				</span>
+				<span onclick={renderTerminalThemes} tabindex={0}>
+					Terminal
 				</span>
 			</div>
 			<div ref={list} id="theme-list" className="list scroll"></div>
@@ -161,6 +167,116 @@ export default function () {
 			return $item;
 		});
 		$currentItem?.scrollIntoView();
+	}
+
+	function renderTerminalThemes() {
+		destroyPreview("switch-tab");
+		$themePreview.innerHTML = "";
+		const currentTheme = appSettings.value.terminalSettings?.theme || "dark";
+
+		if (innerHeight * 0.3 >= 120) {
+			if (!$themePreview.parentElement) {
+				$page.body.append($themePreview);
+			}
+			createTerminalPreview(currentTheme);
+		} else {
+			$themePreview.remove();
+		}
+
+		const themeNames = TerminalThemeManager.getThemeNames();
+		let $currentItem;
+		list.el.content = themeNames.map((name) => {
+			const isCurrent = name === currentTheme;
+			const themeObj = TerminalThemeManager.getTheme(name);
+			const label = name.charAt(0).toUpperCase() + name.slice(1);
+			const $item = (
+				<Item
+					name={label}
+					isCurrent={isCurrent}
+					swatches={[themeObj.background, themeObj.foreground, themeObj.cursor]}
+					onclick={() => setTerminalTheme(name)}
+				/>
+			);
+			if (isCurrent) $currentItem = $item;
+			return $item;
+		});
+		$currentItem?.scrollIntoView();
+	}
+
+	function setTerminalTheme(name) {
+		if (appSettings.value.appTheme?.toLowerCase() === "system") {
+			alert(
+				strings.info,
+				"App theme is set to 'System'. Changing the terminal theme will not affect the terminal appearance.",
+			);
+			return;
+		}
+
+		const currentSettings = appSettings.value.terminalSettings || {};
+		appSettings.update({
+			terminalSettings: {
+				...currentSettings,
+				theme: name,
+			},
+		});
+		if (editorManager != null) {
+			updateActiveTerminals("theme", name);
+		}
+		if ($themePreview.parentElement) {
+			createTerminalPreview(name);
+		}
+		const label = name.charAt(0).toUpperCase() + name.slice(1);
+		updateCheckedItem(label);
+	}
+
+	function createTerminalPreview(themeName) {
+		destroyPreview("create");
+		const theme = TerminalThemeManager.getTheme(themeName);
+		const ansiKeys = [
+			"black",
+			"red",
+			"green",
+			"yellow",
+			"blue",
+			"magenta",
+			"cyan",
+			"white",
+			"brightBlack",
+			"brightRed",
+			"brightGreen",
+			"brightYellow",
+			"brightBlue",
+			"brightMagenta",
+			"brightCyan",
+			"brightWhite",
+		];
+		const swatches = ansiKeys
+			.map(
+				(k) =>
+					`<span class="ansi-swatch" style="background:${theme[k]};" title="${k}"></span>`,
+			)
+			.join("");
+
+		$themePreview.innerHTML = `
+			<div class="terminal-preview-content" style="background:${theme.background};color:${theme.foreground};">
+				<div class="ansi-colors">${swatches}</div>
+				<div class="terminal-line terminal-prompt">
+					<span style="color:${theme.green}">user</span>
+					<span style="color:${theme.foreground}">@</span>
+					<span style="color:${theme.blue}">acode</span>
+					<span style="color:${theme.foreground}">:~$ </span>
+					<span>echo "Hello, Acode!"</span>
+				</div>
+				<div class="terminal-line terminal-output">Hello, Acode!</div>
+				<div class="terminal-line terminal-prompt">
+					<span style="color:${theme.green}">user</span>
+					<span style="color:${theme.foreground}">@</span>
+					<span style="color:${theme.blue}">acode</span>
+					<span style="color:${theme.foreground}">:~$ </span>
+					<span class="terminal-cursor" style="background:${theme.cursor};"></span>
+				</div>
+			</div>
+		`;
 	}
 
 	/**

--- a/src/pages/themeSetting/themeSetting.js
+++ b/src/pages/themeSetting/themeSetting.js
@@ -207,7 +207,7 @@ export default function () {
 		if (appSettings.value.appTheme?.toLowerCase() === "system") {
 			alert(
 				strings.info,
-				"App theme is set to 'System'. Changing the terminal theme will not affect the terminal appearance.",
+				"Terminal theme cannot be changed while the app theme is set to 'System'.",
 			);
 			return;
 		}
@@ -250,33 +250,41 @@ export default function () {
 			"brightCyan",
 			"brightWhite",
 		];
-		const swatches = ansiKeys
-			.map(
-				(k) =>
-					`<span class="ansi-swatch" style="background:${theme[k]};" title="${k}"></span>`,
-			)
-			.join("");
 
-		$themePreview.innerHTML = `
-			<div class="terminal-preview-content" style="background:${theme.background};color:${theme.foreground};">
-				<div class="ansi-colors">${swatches}</div>
-				<div class="terminal-line terminal-prompt">
-					<span style="color:${theme.green}">user</span>
-					<span style="color:${theme.foreground}">@</span>
-					<span style="color:${theme.blue}">acode</span>
-					<span style="color:${theme.foreground}">:~$ </span>
+		const container = (
+			<div
+				className="terminal-preview-content"
+				style={`background:${theme.background};color:${theme.foreground};`}
+			>
+				<div className="ansi-colors">
+					{ansiKeys.map((k) => (
+						<span
+							className="ansi-swatch"
+							style={`background:${theme[k]};`}
+							title={k}
+						></span>
+					))}
+				</div>
+				<div className="terminal-line terminal-prompt">
+					<span style={`color:${theme.green};`}>user</span>
+					<span style={`color:${theme.foreground};`}>@</span>
+					<span style={`color:${theme.blue};`}>acode</span>
+					<span style={`color:${theme.foreground};`}>:~$ </span>
 					<span>echo "Hello, Acode!"</span>
 				</div>
-				<div class="terminal-line terminal-output">Hello, Acode!</div>
-				<div class="terminal-line terminal-prompt">
-					<span style="color:${theme.green}">user</span>
-					<span style="color:${theme.foreground}">@</span>
-					<span style="color:${theme.blue}">acode</span>
-					<span style="color:${theme.foreground}">:~$ </span>
-					<span class="terminal-cursor" style="background:${theme.cursor};"></span>
+				<div className="terminal-line terminal-output">Hello, Acode!</div>
+				<div className="terminal-line terminal-prompt">
+					<span style={`color:${theme.green};`}>user</span>
+					<span style={`color:${theme.foreground};`}>@</span>
+					<span style={`color:${theme.blue};`}>acode</span>
+					<span style={`color:${theme.foreground};`}>:~$ </span>
+					<span className="terminal-cursor" style={`background:${theme.cursor};`}></span>
 				</div>
 			</div>
-		`;
+		);
+
+		$themePreview.innerHTML = "";
+		$themePreview.appendChild(container);
 	}
 
 	/**

--- a/src/pages/themeSetting/themeSetting.js
+++ b/src/pages/themeSetting/themeSetting.js
@@ -278,7 +278,10 @@ export default function () {
 					<span style={`color:${theme.foreground};`}>@</span>
 					<span style={`color:${theme.blue};`}>acode</span>
 					<span style={`color:${theme.foreground};`}>:~$ </span>
-					<span className="terminal-cursor" style={`background:${theme.cursor};`}></span>
+					<span
+						className="terminal-cursor"
+						style={`background:${theme.cursor};`}
+					></span>
 				</div>
 			</div>
 		);

--- a/src/pages/themeSetting/themeSetting.scss
+++ b/src/pages/themeSetting/themeSetting.scss
@@ -66,4 +66,53 @@
       margin-left: 1px;
     }
   }
+
+  .terminal-preview-content {
+    font-family: monospace;
+    font-size: 11px;
+    padding: 10px;
+    border-radius: 6px;
+    width: 100%;
+    height: 100%;
+    box-sizing: border-box;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .ansi-colors {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    gap: 2px;
+    margin-bottom: 6px;
+  }
+
+  .ansi-swatch {
+    display: block;
+    height: 12px;
+    border-radius: 2px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .terminal-line {
+    line-height: 1.4;
+  }
+
+  .terminal-output {
+    color: inherit;
+  }
+
+  .terminal-cursor {
+    display: inline-block;
+    width: 7px;
+    height: 13px;
+    vertical-align: text-bottom;
+    animation: terminal-cursor-blink 1s steps(1) infinite;
+  }
+
+  @keyframes terminal-cursor-blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0; }
+  }
 }

--- a/src/settings/terminalSettings.js
+++ b/src/settings/terminalSettings.js
@@ -69,23 +69,6 @@ export default function terminalSettings() {
 			category: categories.display,
 		},
 		{
-			key: "theme",
-			text: strings["theme"],
-			value: terminalValues.theme,
-			info: strings["info-theme"],
-			get select() {
-				return TerminalThemeManager.getThemeNames().map((name) => [
-					name,
-					name.charAt(0).toUpperCase() + name.slice(1),
-				]);
-			},
-			valueText(value) {
-				const option = this.select.find(([v]) => v === value);
-				return option ? option[1] : value;
-			},
-			category: categories.display,
-		},
-		{
 			key: "fontWeight",
 			text: strings["terminal:font weight"],
 			value: terminalValues.fontWeight,

--- a/src/theme/builder.js
+++ b/src/theme/builder.js
@@ -35,6 +35,7 @@ export default class ThemeBuilder {
 	/** Whether Auto update darkened primary color when primary color is updated. */
 	autoDarkened = true;
 	preferredEditorTheme = null;
+	preferredTerminalTheme = null;
 	preferredFont = null;
 
 	/**

--- a/src/theme/list.js
+++ b/src/theme/list.js
@@ -113,7 +113,7 @@ export async function apply(id, init) {
 		fonts.setFont(theme.preferredFont);
 	}
 
-	if (init && theme.preferredTerminalTheme) {
+	if (init && firstTime && theme.preferredTerminalTheme) {
 		update.terminalSettings = {
 			...(settings.value.terminalSettings || {}),
 			theme: theme.preferredTerminalTheme,
@@ -122,7 +122,7 @@ export async function apply(id, init) {
 
 	settings.update(update, false);
 
-	if (init && theme.preferredTerminalTheme) {
+	if (init && firstTime && theme.preferredTerminalTheme) {
 		if (editorManager != null) {
 			updateActiveTerminals("theme", theme.preferredTerminalTheme);
 		}

--- a/src/theme/list.js
+++ b/src/theme/list.js
@@ -4,6 +4,7 @@ import color from "utils/color";
 import Url from "utils/Url";
 import fonts from "../lib/fonts";
 import settings from "../lib/settings";
+import { updateActiveTerminals } from "../settings/terminalSettings";
 import ThemeBuilder from "./builder";
 import themes, { updateSystemTheme } from "./preInstalled";
 
@@ -112,7 +113,20 @@ export async function apply(id, init) {
 		fonts.setFont(theme.preferredFont);
 	}
 
+	if (init && theme.preferredTerminalTheme) {
+		update.terminalSettings = {
+			...(settings.value.terminalSettings || {}),
+			theme: theme.preferredTerminalTheme,
+		};
+	}
+
 	settings.update(update, false);
+
+	if (init && theme.preferredTerminalTheme) {
+		if (editorManager != null) {
+			updateActiveTerminals("theme", theme.preferredTerminalTheme);
+		}
+	}
 	localStorage.__primary_color = theme.primaryColor;
 	document.body.setAttribute("theme-type", theme.type);
 	$style.textContent = theme.css;

--- a/src/theme/preInstalled.js
+++ b/src/theme/preInstalled.js
@@ -21,6 +21,7 @@ dark.errorTextColor = "rgb(255, 185, 92)";
 dark.dangerColor = "rgb(220, 38, 38)";
 dark.scrollbarColor = "rgba(255, 255, 255, 0.2)";
 dark.preferredEditorTheme = getSystemEditorTheme(true);
+dark.preferredTerminalTheme = "dark";
 
 const oled = createBuiltInTheme("OLED");
 oled.primaryColor = "rgb(0, 0, 0)";
@@ -46,6 +47,7 @@ oled.errorTextColor = "rgb(255, 69, 58)";
 oled.dangerColor = "rgb(255, 69, 58)";
 oled.scrollbarColor = "rgba(255, 255, 255, 0.1)";
 oled.preferredEditorTheme = "tokyoNight";
+oled.preferredTerminalTheme = "dark";
 
 const ocean = createBuiltInTheme("Ocean");
 ocean.darkenedPrimaryColor = "rgb(19, 19, 26)";
@@ -63,6 +65,7 @@ ocean.popupActiveColor = "rgb(255, 215, 0)";
 ocean.boxShadowColor = "rgba(0, 0, 0, 0.5)";
 ocean.preferredEditorTheme = "solarizedDark";
 ocean.preferredFont = "Fira Code";
+ocean.preferredTerminalTheme = "ocean";
 
 const bump = createBuiltInTheme("Bump");
 bump.darkenedPrimaryColor = "rgb(24, 28, 36)";
@@ -86,6 +89,7 @@ bump.errorTextColor = "rgb(255, 180, 100)";
 bump.dangerColor = "rgb(240, 70, 60)";
 bump.scrollbarColor = "rgba(230, 232, 238, 0.12)";
 bump.preferredEditorTheme = "one_dark";
+bump.preferredTerminalTheme = "oneDark";
 
 const bling = createBuiltInTheme("Bling");
 bling.darkenedPrimaryColor = "rgb(16, 12, 28)";
@@ -109,6 +113,7 @@ bling.errorTextColor = "rgb(255, 170, 100)";
 bling.dangerColor = "rgb(240, 85, 85)";
 bling.scrollbarColor = "rgba(228, 225, 240, 0.1)";
 bling.preferredEditorTheme = "tokyoNight";
+bling.preferredTerminalTheme = "tokyoNight";
 
 const moon = createBuiltInTheme("Moon");
 moon.darkenedPrimaryColor = "rgb(16, 20, 26)";
@@ -132,6 +137,7 @@ moon.errorTextColor = "rgb(255, 170, 105)";
 moon.dangerColor = "rgb(235, 75, 70)";
 moon.scrollbarColor = "rgba(210, 225, 230, 0.12)";
 moon.preferredEditorTheme = "tokyoNight";
+moon.preferredTerminalTheme = "nord";
 
 const atticus = createBuiltInTheme("Atticus");
 atticus.darkenedPrimaryColor = "rgb(26, 24, 22)";
@@ -155,6 +161,7 @@ atticus.errorTextColor = "rgb(240, 160, 90)";
 atticus.dangerColor = "rgb(210, 65, 55)";
 atticus.scrollbarColor = "rgba(228, 222, 212, 0.12)";
 atticus.preferredEditorTheme = "monokai";
+atticus.preferredTerminalTheme = "gruvbox";
 
 const tomyris = createBuiltInTheme("Tomyris");
 tomyris.darkenedPrimaryColor = "rgb(22, 12, 20)";
@@ -178,6 +185,7 @@ tomyris.errorTextColor = "rgb(255, 175, 100)";
 tomyris.dangerColor = "rgb(235, 65, 65)";
 tomyris.scrollbarColor = "rgba(235, 225, 232, 0.1)";
 tomyris.preferredEditorTheme = "monokai";
+tomyris.preferredTerminalTheme = "dracula";
 
 const menes = createBuiltInTheme("Menes");
 menes.darkenedPrimaryColor = "rgb(18, 22, 28)";
@@ -201,6 +209,7 @@ menes.errorTextColor = "rgb(255, 165, 95)";
 menes.dangerColor = "rgb(240, 75, 65)";
 menes.scrollbarColor = "rgba(225, 230, 240, 0.12)";
 menes.preferredEditorTheme = "one_dark";
+menes.preferredTerminalTheme = "oneDark";
 
 const light = createBuiltInTheme("Light", "light");
 light.primaryColor = "rgb(255, 255, 255)";
@@ -219,6 +228,7 @@ light.errorTextColor = "rgb(185, 28, 28)";
 light.dangerColor = "rgb(220, 38, 38)";
 light.scrollbarColor = "rgba(0, 0, 0, 0.2)";
 light.preferredEditorTheme = getSystemEditorTheme(false);
+light.preferredTerminalTheme = "light";
 
 const system = createBuiltInTheme("System", "dark", "free");
 
@@ -294,6 +304,7 @@ glass.activeTextColor = "rgb(255, 255, 255)";
 glass.errorTextColor = "rgb(185, 28, 28)";
 glass.dangerColor = "rgb(220, 38, 38)";
 glass.scrollbarColor = "rgba(0, 0, 0, 0.15)";
+glass.preferredTerminalTheme = "glass";
 
 const neon = createBuiltInTheme("Neon");
 neon.darkenedPrimaryColor = "rgb(9, 9, 11)";
@@ -317,6 +328,7 @@ neon.activeTextColor = "rgb(0, 0, 0)";
 neon.errorTextColor = "rgb(255, 20, 147)";
 neon.dangerColor = "rgb(255, 20, 147)";
 neon.scrollbarColor = "rgba(10, 255, 200, 0.3)";
+neon.preferredTerminalTheme = "synthwave";
 
 const glassDark = createBuiltInTheme("Glass Dark", "dark");
 glassDark.darkenedPrimaryColor = "rgb(15, 15, 20)";
@@ -340,6 +352,7 @@ glassDark.errorTextColor = "rgb(248, 113, 113)";
 glassDark.dangerColor = "rgb(239, 68, 68)";
 glassDark.scrollbarColor = "rgba(255, 255, 255, 0.2)";
 glassDark.preferredEditorTheme = "tokyoNight";
+glassDark.preferredTerminalTheme = "glassDark";
 
 const sunset = createBuiltInTheme("Sunset");
 sunset.darkenedPrimaryColor = "rgb(251, 243, 235)";
@@ -361,6 +374,7 @@ sunset.activeTextColor = "rgb(255, 255, 255)";
 sunset.errorTextColor = "rgb(185, 28, 28)";
 sunset.dangerColor = "rgb(220, 38, 38)";
 sunset.scrollbarColor = "rgba(124, 45, 18, 0.2)";
+sunset.preferredTerminalTheme = "sunset";
 
 const obsidian = createBuiltInTheme("Obsidian");
 obsidian.darkenedPrimaryColor = "rgb(18, 17, 21)";
@@ -384,6 +398,7 @@ obsidian.errorTextColor = "rgb(255, 152, 100)";
 obsidian.dangerColor = "rgb(220, 80, 60)";
 obsidian.scrollbarColor = "rgba(212, 175, 55, 0.18)";
 obsidian.preferredEditorTheme = "one_dark";
+obsidian.preferredTerminalTheme = "oneDark";
 
 const ember = createBuiltInTheme("Ember");
 ember.darkenedPrimaryColor = "rgb(22, 16, 13)";
@@ -407,6 +422,7 @@ ember.errorTextColor = "rgb(255, 160, 85)";
 ember.dangerColor = "rgb(220, 60, 50)";
 ember.scrollbarColor = "rgba(240, 228, 210, 0.12)";
 ember.preferredEditorTheme = "monokai";
+ember.preferredTerminalTheme = "sunset";
 
 const dusk = createBuiltInTheme("Dusk");
 dusk.darkenedPrimaryColor = "rgb(13, 11, 24)";
@@ -430,6 +446,7 @@ dusk.errorTextColor = "rgb(255, 170, 110)";
 dusk.dangerColor = "rgb(235, 80, 100)";
 dusk.scrollbarColor = "rgba(215, 210, 235, 0.12)";
 dusk.preferredEditorTheme = "tokyoNight";
+dusk.preferredTerminalTheme = "tokyoNight";
 
 const carbon = createBuiltInTheme("Carbon");
 carbon.darkenedPrimaryColor = "rgb(14, 14, 16)";
@@ -453,6 +470,7 @@ carbon.errorTextColor = "rgb(255, 140, 100)";
 carbon.dangerColor = "rgb(235, 70, 60)";
 carbon.scrollbarColor = "rgba(255, 255, 255, 0.1)";
 carbon.preferredEditorTheme = "one_dark";
+carbon.preferredTerminalTheme = "oneDark";
 
 const mint = createBuiltInTheme("Mint", "light");
 mint.darkenedPrimaryColor = "rgb(235, 245, 240)";
@@ -476,6 +494,7 @@ mint.errorTextColor = "rgb(190, 40, 40)";
 mint.dangerColor = "rgb(220, 38, 38)";
 mint.scrollbarColor = "rgba(28, 42, 38, 0.12)";
 mint.preferredEditorTheme = "noctisLilac";
+mint.preferredTerminalTheme = "light";
 
 const sandstone = createBuiltInTheme("Sandstone", "light");
 sandstone.darkenedPrimaryColor = "rgb(238, 230, 218)";
@@ -499,6 +518,7 @@ sandstone.errorTextColor = "rgb(180, 40, 35)";
 sandstone.dangerColor = "rgb(200, 50, 45)";
 sandstone.scrollbarColor = "rgba(60, 45, 35, 0.12)";
 sandstone.preferredEditorTheme = "noctisLilac";
+sandstone.preferredTerminalTheme = "solarizedLight";
 
 const blossom = createBuiltInTheme("Blossom", "light");
 blossom.darkenedPrimaryColor = "rgb(242, 234, 237)";
@@ -522,6 +542,7 @@ blossom.errorTextColor = "rgb(200, 45, 40)";
 blossom.dangerColor = "rgb(210, 50, 45)";
 blossom.scrollbarColor = "rgba(48, 38, 42, 0.12)";
 blossom.preferredEditorTheme = "noctisLilac";
+blossom.preferredTerminalTheme = "light";
 
 const custom = createBuiltInTheme("Custom");
 custom.autoDarkened = true;


### PR DESCRIPTION
- Move terminal theme selection from Terminal Settings to a new "Terminal" tab in Theme Settings with a live preview showing ANSI colors, sample prompt, and cursor blink animation
- Add preferredTerminalTheme to ThemeBuilder and assign matching terminal themes to all built-in app themes
- Auto-apply preferred terminal theme when switching app themes via themes.apply()
- Remove terminal theme field from Terminal Settings
- Fix: clear preview DOM before switching to terminal tab to prevent CodeMirror DOM leakage
- Fix: guard updateActiveTerminals() call against null editorManager in setTerminalTheme (matching safe pattern in theme/list.js)