### PR TITLE
fix: version parsing failure on nightly tags

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -338,11 +338,22 @@ async function onDeviceReady() {
 			(response) => {
 				const release = response.data;
 				// assuming version is in format v1.2.3
+				const versionFormat = /^v?(\d+(?:\.\d+)*)/;
 				const latestVersion = release.tag_name
-					.replace("v", "")
+					.match(versionFormat)?.[1]
 					.split(".")
 					.map(Number);
-				const currentVersion = BuildInfo.version.split(".").map(Number);
+				const currentVersion = BuildInfo.version
+					.match(versionFormat)?.[1]
+					.split(".")
+					.map(Number);
+				if (!(latestVersion && currentVersion)) {
+					window.log(
+						"error",
+						"Failed to parse version while checking for updates.",
+					);
+					return;
+				}
 
 				let hasUpdate = false;
 				for (let i = 0; i < latestVersion.length; i++) {


### PR DESCRIPTION
Refactors the update-checking logic to use regular expression matching instead of basic string replacement when parsing version tags.

Previously, passing a nightly string like "1.12.5-nightly.xxxx" through `.replace("v", "").split(".")` resulted in non-numeric array elements (e.g., "5-nightly"), which evaluated to `NaN` and broke downstream version comparison checks.

Changes implemented:
* Replaced string replacement with `.match(/^v?(\d+(?:\.\d+)*)/)?.[1]` to cleanly isolate the leading numeric SemVer elements.
* Applied matching symmetrically across both `release.tag_name` and `BuildInfo.version` arrays to guarantee structural parsing alignment.

<sub>(PR name and description are AI generated)</sub>