### PR TITLE
feat(quickTools): replace checkbox with height select & dynamic toggler

### DIFF
--- a/src/components/quickTools/items.js
+++ b/src/components/quickTools/items.js
@@ -46,6 +46,7 @@ export default [
 	item("modulo", "letters", "insert", "%", "%"),
 	item("caret", "letters", "insert", "^", "^"),
 	item("hyphen", "letters", "insert", "-", "-"),
+	item("paste", "paste", "command", "paste"),
 ];
 
 /**
@@ -54,7 +55,7 @@ export default [
  * @returns
  */
 export function description(id) {
-	return strings[`quicktools:${id}`];
+	return strings[`quicktools:${id}`] || strings[id];
 }
 
 /**

--- a/src/components/quickTools/style.scss
+++ b/src/components/quickTools/style.scss
@@ -1,10 +1,19 @@
 @use '../../styles/mixins.scss';
 
 #quick-tools {
-  .icon.click {
+  .icon.click:not([disabled]) {
     @include mixins.active-icon;
     transition: all 0.3s ease-in-out;
     transform: scale(1.2);
+  }
+
+  [disabled] {
+    cursor: default;
+    opacity: 0.45;
+  }
+
+  [data-id="paste"] {
+    font-size: 0.9em;
   }
 
   &[data-alt="true"] {

--- a/src/components/searchbar/index.js
+++ b/src/components/searchbar/index.js
@@ -184,9 +184,28 @@ function searchBar($list, setHide, onhideCb, searchFunction) {
 	function cloneSearchItem($item) {
 		const $clone = $item.cloneNode(true);
 		$clone.addEventListener("click", () => {
+			$item.addEventListener(
+				"settings-item-interaction-end",
+				(event) => {
+					if (event.detail?.updated) {
+						syncSearchClone($clone, $item);
+					}
+				},
+				{ once: true },
+			);
 			$item.click();
 		});
 		return $clone;
+	}
+
+	/**
+	 * Keep a visible search-result clone in sync after the backing item updates.
+	 * @param {HTMLElement} $clone
+	 * @param {HTMLElement} $item
+	 */
+	function syncSearchClone($clone, $item) {
+		$clone.className = $item.className;
+		$clone.innerHTML = $item.innerHTML;
 	}
 }
 

--- a/src/components/settingsPage.js
+++ b/src/components/settingsPage.js
@@ -233,15 +233,29 @@ function listItems($list, items, callback, options = {}) {
 		const item = itemByKey.get(key);
 		if (!item) return;
 		const result = await resolveItemInteraction(item, $target);
-		if (result.shouldCallCallback === false) return;
-		if (!result.shouldUpdateValue)
+		if (result.shouldCallCallback === false) {
+			dispatchItemInteractionEnd($target, false);
+			return;
+		}
+		if (!result.shouldUpdateValue) {
+			dispatchItemInteractionEnd($target, false);
 			return callback.call($target, key, item.value);
+		}
 
 		item.value = result.value;
 		updateItemValueDisplay($target, item, options, useInfoAsDescription);
+		dispatchItemInteractionEnd($target, true);
 
 		callback.call($target, key, item.value);
 	}
+}
+
+function dispatchItemInteractionEnd($target, updated) {
+	$target.dispatchEvent(
+		new CustomEvent("settings-item-interaction-end", {
+			detail: { updated },
+		}),
+	);
 }
 
 function normalizeSettings(settings) {

--- a/src/handlers/quickTools.js
+++ b/src/handlers/quickTools.js
@@ -21,6 +21,7 @@ export let quickToolUsed = false;
 let input;
 /** @type {number} */
 let quickToolUsedTimeout = null;
+let activeSearchState = null;
 
 const state = {
 	shift: false,
@@ -348,6 +349,7 @@ function toggleSearch() {
 		const { className } = quickTools.$toggler;
 		const $content = [...$footer.children];
 		const footerHeight = getFooterHeight();
+		activeSearchState = { className, content: $content, footerHeight };
 
 		$toggler.className = "floating icon clearclose";
 		$footer.content = [$searchRow1, $searchRow2];
@@ -375,10 +377,16 @@ function toggleSearch() {
 		actionStack.push({
 			id: "search-bar",
 			action: () => {
+				const restoreState = activeSearchState || {
+					className,
+					content: $content,
+					footerHeight,
+				};
 				removeSearch();
-				$footer.content = $content;
-				$toggler.className = className;
-				setFooterHeight(footerHeight);
+				$footer.content = restoreState.content;
+				$toggler.className = restoreState.className;
+				setFooterHeight(restoreState.footerHeight);
+				activeSearchState = null;
 			},
 		});
 	} else {
@@ -427,6 +435,25 @@ function setHeight(height = 1, save = true) {
 		save = false;
 	}
 
+	const searchBar = actionStack.get("search-bar");
+	if (searchBar?.action) {
+		if (height === 0) {
+			searchBar.action();
+		} else {
+			const footerHeight = Number(height) || 0;
+			activeSearchState = {
+				className:
+					activeSearchState?.className || quickTools.$toggler.className,
+				content: getQuickToolsRows(footerHeight),
+				footerHeight,
+			};
+			if (save) {
+				appSettings.update({ quickTools: height }, false);
+			}
+			return;
+		}
+	}
+
 	setFooterHeight(height);
 	if (save) {
 		appSettings.update({ quickTools: height }, false);
@@ -455,6 +482,11 @@ function setHeight(height = 1, save = true) {
 	} else {
 		$row2.remove();
 	}
+}
+
+function getQuickToolsRows(height) {
+	const { $row1, $row2 } = quickTools;
+	return [$row1, $row2].slice(0, height);
 }
 
 /**

--- a/src/handlers/quickTools.js
+++ b/src/handlers/quickTools.js
@@ -432,12 +432,6 @@ function setHeight(height = 1, save = true) {
 		appSettings.update({ quickTools: height }, false);
 	}
 
-	if (!height) {
-		$row1.remove();
-		$row2.remove();
-		return;
-	}
-
 	if (height >= 1) {
 		$row1.style.scrollBehavior = "unset";
 		$footer.append($row1);
@@ -446,6 +440,8 @@ function setHeight(height = 1, save = true) {
 			10,
 		);
 		--height;
+	} else {
+		$row1.remove();
 	}
 
 	if (height >= 1) {
@@ -456,6 +452,8 @@ function setHeight(height = 1, save = true) {
 			10,
 		);
 		--height;
+	} else {
+		$row2.remove();
 	}
 }
 

--- a/src/handlers/quickToolsInit.js
+++ b/src/handlers/quickToolsInit.js
@@ -84,7 +84,10 @@ export default function init() {
 		$footer.removeAttribute("data-unsaved");
 	});
 
-	root.append($footer, $toggler);
+	root.append($footer);
+	if (appSettings.value.floatingButton) {
+		root.appendOuter($toggler);
+	}
 	document.body.append($input);
 	if (
 		appSettings.value.quickToolsTriggerMode ===

--- a/src/handlers/quickToolsInit.js
+++ b/src/handlers/quickToolsInit.js
@@ -1,3 +1,4 @@
+import { redoDepth, undoDepth } from "@codemirror/commands";
 import quickTools from "components/quickTools";
 import config from "lib/config";
 import appSettings from "lib/settings";
@@ -78,10 +79,17 @@ export default function init() {
 		} else {
 			$footer.removeAttribute("data-unsaved");
 		}
+		updateHistoryButtons();
 	});
 
 	editorManager.on("save-file", () => {
 		$footer.removeAttribute("data-unsaved");
+	});
+
+	editorManager.on("editor-state-changed", updateHistoryButtons);
+
+	appSettings.on("update:quicktoolsItems:after", () => {
+		setTimeout(updateHistoryButtons, 100);
 	});
 
 	root.append($footer);
@@ -89,6 +97,8 @@ export default function init() {
 		root.appendOuter($toggler);
 	}
 	document.body.append($input);
+	setTimeout(updateHistoryButtons, 0);
+
 	if (
 		appSettings.value.quickToolsTriggerMode ===
 		appSettings.QUICKTOOLS_TRIGGER_MODE_CLICK
@@ -139,6 +149,12 @@ function onwheel(e) {
 function onclick(e) {
 	reset();
 
+	if (e.target.disabled) {
+		e.preventDefault();
+		e.stopPropagation();
+		return;
+	}
+
 	e.preventDefault();
 	e.stopPropagation();
 	click(e.target);
@@ -150,6 +166,11 @@ function touchstart(e) {
 
 	const $el = e.target;
 	if ($el instanceof HTMLInputElement) {
+		return;
+	}
+	if ($el.disabled) {
+		e.preventDefault();
+		e.stopPropagation();
 		return;
 	}
 
@@ -329,6 +350,8 @@ function oncontextmenu(e) {
  * @param {HTMLElement} $el
  */
 function click($el) {
+	if ($el.disabled) return;
+
 	$el.classList.add("click");
 	clearTimeout($el.dataset.timeout);
 	$el.dataset.timeout = setTimeout(() => {
@@ -349,4 +372,21 @@ function click($el) {
 	}
 
 	actions(action, value);
+}
+
+function updateHistoryButtons() {
+	const { editor, activeFile } = editorManager;
+	const disabled = !editor || activeFile?.type !== "editor";
+
+	updateHistoryButton("undo", disabled || undoDepth(editor.state) === 0);
+	updateHistoryButton("redo", disabled || redoDepth(editor.state) === 0);
+}
+
+function updateHistoryButton(id, disabled) {
+	quickTools.$footer
+		.querySelectorAll(`[data-id="${id}"]`)
+		.forEach(($button) => {
+			$button.disabled = disabled;
+			$button.setAttribute("aria-disabled", String(disabled));
+		});
 }

--- a/src/lang/ar-ye.json
+++ b/src/lang/ar-ye.json
@@ -146,7 +146,6 @@
 	"none": "بلا",
 	"small": "صغير",
 	"large": "كبير",
-	"floating button": "الزر العائم",
 	"confirm on exit": "تأكيد عند الخروج",
 	"show console": "إظهار وحدة التحكم",
 	"image": "صورة",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "مضغوط",
+	"off": "إيقاف",
+	"quick tools height": "ارتفاع الأدوات السريعة",
+	"quick tools toggler": "مبدل الأدوات السريعة"
 }

--- a/src/lang/be-by.json
+++ b/src/lang/be-by.json
@@ -146,7 +146,6 @@
 	"none": "Няма",
 	"small": "Маленькі",
 	"large": "Вялікі",
-	"floating button": "Выплыўная панэль кнопак",
 	"confirm on exit": "Пацвярджэнне выхаду",
 	"show console": "Паказваць кансоль",
 	"image": "Выява",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Кампактны",
+	"off": "Выкл",
+	"quick tools height": "Вышыня хуткіх інструментаў",
+	"quick tools toggler": "Пераключальнік хуткіх інструментаў"
 }

--- a/src/lang/bn-bd.json
+++ b/src/lang/bn-bd.json
@@ -146,7 +146,6 @@
 	"none": "none",
 	"small": "ছোট",
 	"large": "বড়",
-	"floating button": "ভাসমান বাটোন",
 	"confirm on exit": "প্রস্থান নিশ্চিত করুন",
 	"show console": "কনসোল দেখান",
 	"image": "ছবি",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "কম্প্যাক্ট",
+	"off": "বন্ধ",
+	"quick tools height": "কুইক টুলসের উচ্চতা",
+	"quick tools toggler": "কুইক টুলস টগলার"
 }

--- a/src/lang/cs-cz.json
+++ b/src/lang/cs-cz.json
@@ -146,7 +146,6 @@
 	"none": "Žádná",
 	"small": "Malá",
 	"large": "Velká",
-	"floating button": "Plovoucí tlačítko",
 	"confirm on exit": "Potvrdit při zavření",
 	"show console": "Zobrazit konzoli",
 	"image": "Obrázek",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Kompaktní",
+	"off": "Vypnuto",
+	"quick tools height": "Výška rychlých nástrojů",
+	"quick tools toggler": "Přepínač rychlých nástrojů"
 }

--- a/src/lang/de-de.json
+++ b/src/lang/de-de.json
@@ -146,7 +146,6 @@
 	"none": "Keiner",
 	"small": "Klein",
 	"large": "Groß",
-	"floating button": "Schwebende Schaltfläche",
 	"confirm on exit": "Bestätigung beim Beenden",
 	"show console": "Konsole anzeigen",
 	"image": "Bild",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Kompakt",
+	"off": "Aus",
+	"quick tools height": "Schnelltools-Höhe",
+	"quick tools toggler": "Schnelltools-Umschalter"
 }

--- a/src/lang/en-us.json
+++ b/src/lang/en-us.json
@@ -156,7 +156,6 @@
 	"none": "None",
 	"small": "Small",
 	"large": "Large",
-	"floating button": "Floating button",
 	"confirm on exit": "Confirm on exit",
 	"show console": "Show console",
 	"image": "Image",
@@ -760,5 +759,9 @@
 	"iap-pro-purchase-warning": "This purchase will not be synced to your Acode account. Use same Google account in play store to restore your purchase.",
 	"confirm-login": "You are not singed in to Acode, sign in now?",
 	"terminal:failsafe": "FailSafe mode",
-	"terminal:failsafe-info": "Start terminal with system shell"
+	"terminal:failsafe-info": "Start terminal with system shell",
+	"compact": "Compact",
+	"off": "Off",
+	"quick tools height": "Quick tools height",
+	"quick tools toggler": "Quick tools toggler"
 }

--- a/src/lang/es-sv.json
+++ b/src/lang/es-sv.json
@@ -146,7 +146,6 @@
 	"none": "ninguno",
 	"small": "pequeño",
 	"large": "grande",
-	"floating button": "Botón flotante",
 	"confirm on exit": "Confirmar al salir",
 	"show console": "Mostrar consola",
 	"image": "Imagen",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Compacto",
+	"off": "Apagado",
+	"quick tools height": "Altura de herramientas rápidas",
+	"quick tools toggler": "Alternador de herramientas rápidas"
 }

--- a/src/lang/fr-fr.json
+++ b/src/lang/fr-fr.json
@@ -146,7 +146,6 @@
 	"none": "Aucun",
 	"small": "Petit",
 	"large": "Grand",
-	"floating button": "Bouton flottant",
 	"confirm on exit": "Confirmer pour quitter",
 	"show console": "Afficher la console",
 	"image": "Image",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Compact",
+	"off": "Désactivé",
+	"quick tools height": "Hauteur des outils rapides",
+	"quick tools toggler": "Bascule des outils rapides"
 }

--- a/src/lang/he-il.json
+++ b/src/lang/he-il.json
@@ -146,7 +146,6 @@
 	"none": "ללא",
 	"small": "קטן",
 	"large": "גדול",
-	"floating button": "כפתור צף",
 	"confirm on exit": "אמת יציאה",
 	"show console": "הצג קונסולה",
 	"image": "תמונה",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "קומפקטי",
+	"off": "כבוי",
+	"quick tools height": "גובה כלים מהירים",
+	"quick tools toggler": "מחליף כלים מהירים"
 }

--- a/src/lang/hi-in.json
+++ b/src/lang/hi-in.json
@@ -144,7 +144,6 @@
 	"none": "कोई भी नहीं",
 	"small": "छोटा",
 	"large": "विशाल",
-	"floating button": "फ्लोटिंग बटन",
 	"confirm on exit": "बाहर निकलने पर पुष्टि करें",
 	"show console": "कंसोल दिखाएँ",
 	"image": "इमेज",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "संक्षिप्त",
+	"off": "बंद",
+	"quick tools height": "त्वरित उपकरण ऊंचाई",
+	"quick tools toggler": "त्वरित उपकरण टॉगलर"
 }

--- a/src/lang/hu-hu.json
+++ b/src/lang/hu-hu.json
@@ -146,7 +146,6 @@
 	"none": "Egyik sem",
 	"small": "Kicsi",
 	"large": "Nagy",
-	"floating button": "Lebegő gomb",
 	"confirm on exit": "Megerősítés kérése kilépéskor",
 	"show console": "Konzol megjelenítése",
 	"image": "Kép",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Kompakt",
+	"off": "Ki",
+	"quick tools height": "Gyorseszközök magassága",
+	"quick tools toggler": "Gyorseszközök kapcsoló"
 }

--- a/src/lang/id-id.json
+++ b/src/lang/id-id.json
@@ -146,7 +146,6 @@
 	"none": "Tidak ada",
 	"small": "Kecil",
 	"large": "Besar",
-	"floating button": "Tombol mengambang",
 	"confirm on exit": "Konfirmasi saat keluar",
 	"show console": "Tampilkan konsol",
 	"image": "Gambar",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Tinggi bilah gulir",
 	"full": "Penuh",
 	"scroll past end": "Gulir melewati akhir",
-	"settings-info-scroll-past-end": "Menambahkan spasi kosong ekstra di bawah editor, memungkinkan Anda untuk gulir baris terakhir ke atas."
+	"settings-info-scroll-past-end": "Menambahkan spasi kosong ekstra di bawah editor, memungkinkan Anda untuk gulir baris terakhir ke atas.",
+	"compact": "Ringkas",
+	"off": "Mati",
+	"quick tools height": "Tinggi alat cepat",
+	"quick tools toggler": "Pengalih alat cepat"
 }

--- a/src/lang/ir-fa.json
+++ b/src/lang/ir-fa.json
@@ -146,7 +146,6 @@
 	"none": "none",
 	"small": "small",
 	"large": "large",
-	"floating button": "Floating button",
 	"confirm on exit": "Confirm on exit",
 	"show console": "Show console",
 	"image": "Image",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "فشرده",
+	"off": "خاموش",
+	"quick tools height": "ارتفاع ابزار سریع",
+	"quick tools toggler": "تغییر دهنده ابزار سریع"
 }

--- a/src/lang/it-it.json
+++ b/src/lang/it-it.json
@@ -146,7 +146,6 @@
 	"none": "niente",
 	"small": "piccolo",
 	"large": "grande",
-	"floating button": "Bottone fluttuante",
 	"confirm on exit": "Conferma all'uscita",
 	"show console": "Mostra la console",
 	"image": "Immagine",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Compatto",
+	"off": "Spento",
+	"quick tools height": "Altezza strumenti veloci",
+	"quick tools toggler": "Attivatore strumenti veloci"
 }

--- a/src/lang/ja-jp.json
+++ b/src/lang/ja-jp.json
@@ -146,7 +146,6 @@
 	"none": "なし",
 	"small": "小",
 	"large": "大",
-	"floating button": "フローティングボタン",
 	"confirm on exit": "アプリケーション終了時に確認",
 	"show console": "コンソールを表示",
 	"image": "画像",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "コンパクト",
+	"off": "オフ",
+	"quick tools height": "クイックツールの高さ",
+	"quick tools toggler": "クイックツール切替"
 }

--- a/src/lang/ko-kr.json
+++ b/src/lang/ko-kr.json
@@ -146,7 +146,6 @@
 	"none": "없음",
 	"small": "작은",
 	"large": "큰",
-	"floating button": "유동적인 버튼",
 	"confirm on exit": "엡 종료시 확인",
 	"show console": "콘솔 보기",
 	"image": "사진",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "컴팩트",
+	"off": "끄기",
+	"quick tools height": "퀵툴 높이",
+	"quick tools toggler": "퀵툴 토글러"
 }

--- a/src/lang/ml-in.json
+++ b/src/lang/ml-in.json
@@ -146,7 +146,6 @@
 	"none": "ഒന്നുമില്ല",
 	"small": "ചെറുത്",
 	"large": "വലുത്",
-	"floating button": "ഫ്ലോട്ടിങ് ബട്ടൺ",
 	"confirm on exit": "കൺഫേം ഓൺ എക്സിറ് ",
 	"show console": "കൺസോൾ കാണിക്കുക",
 	"image": "ചിത്രം",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "കോംപാക്റ്റ്",
+	"off": "ഓഫ്",
+	"quick tools height": "ദ്രുത ഉപകരണ ഉയരം",
+	"quick tools toggler": "ദ്രുത ഉപകരണ ടോഗ്ലർ"
 }

--- a/src/lang/mm-unicode.json
+++ b/src/lang/mm-unicode.json
@@ -146,7 +146,6 @@
 	"none": "none",
 	"small": "သေးမည်",
 	"large": "ကြီးမည်",
-	"floating button": "Floating button",
 	"confirm on exit": "App မှထွက်လျှင် Confirm Button နှိပ်ရမည်",
 	"show console": "console ကိုပြမည်",
 	"image": "Image",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Compact",
+	"off": "Off",
+	"quick tools height": "Quick tools height",
+	"quick tools toggler": "Quick tools toggler"
 }

--- a/src/lang/mm-zawgyi.json
+++ b/src/lang/mm-zawgyi.json
@@ -146,7 +146,6 @@
 	"none": "none",
 	"small": "ေသးမည္",
 	"large": "ႀကီးမည္",
-	"floating button": "Floating button",
 	"confirm on exit": "App မွထြက္လွ်င္ Confirm Button ႏွိပ္ရမည္",
 	"show console": "console ကိုျပမည္",
 	"image": "Image",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Compact",
+	"off": "Off",
+	"quick tools height": "Quick tools height",
+	"quick tools toggler": "Quick tools toggler"
 }

--- a/src/lang/pl-pl.json
+++ b/src/lang/pl-pl.json
@@ -146,7 +146,6 @@
 	"none": "Brak",
 	"small": "Mały",
 	"large": "Duży",
-	"floating button": "Pływający przycisk",
 	"confirm on exit": "Potwierdź przy wyjściu",
 	"show console": "Pokaż konsolę",
 	"image": "Zdjęcie",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Kompaktowy",
+	"off": "Wyłączone",
+	"quick tools height": "Wysokość szybkich narzędzi",
+	"quick tools toggler": "Przełącznik szybkich narzędzi"
 }

--- a/src/lang/pt-br.json
+++ b/src/lang/pt-br.json
@@ -146,7 +146,6 @@
 	"none": "Nenhum",
 	"small": "Pequeno",
 	"large": "Grande",
-	"floating button": "Botão flutuante",
 	"confirm on exit": "Confirmar saída",
 	"show console": "Mostrar console",
 	"image": "Imagem",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Compacto",
+	"off": "Desligado",
+	"quick tools height": "Altura das ferramentas rápidas",
+	"quick tools toggler": "Alternador de ferramentas rápidas"
 }

--- a/src/lang/pu-in.json
+++ b/src/lang/pu-in.json
@@ -146,7 +146,6 @@
 	"none": "ਕੋਈ ਨਹੀਂ",
 	"small": "ਛੋਟਾ",
 	"large": "ਵੱਡਾ",
-	"floating button": "ਫਲੋਟਿੰਗ ਬਟਨ",
 	"confirm on exit": "ਬੰਦ ਹੋਣ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ",
 	"show console": "ਕੰਸੋਲ ਦਿਖਾਓ",
 	"image": "ਚਿੱਤਰ",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "ਸੰਖੇਪ",
+	"off": "ਬੰਦ",
+	"quick tools height": "ਤੇਜ਼ ਟੂਲ ਦੀ ਉਚਾਈ",
+	"quick tools toggler": "ਤੇਜ਼ ਟੂਲ ਟੌਗਲਰ"
 }

--- a/src/lang/ru-ru.json
+++ b/src/lang/ru-ru.json
@@ -146,7 +146,6 @@
 	"none": "Выкл.",
 	"small": "Маленький",
 	"large": "Большой",
-	"floating button": "Плавающая кнопка",
 	"confirm on exit": "Подтверждение перед выходом",
 	"show console": "Показать консоль",
 	"image": "Изображение",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Компактный",
+	"off": "Выкл",
+	"quick tools height": "Высота быстрых инструментов",
+	"quick tools toggler": "Переключатель быстрых инструментов"
 }

--- a/src/lang/tl-ph.json
+++ b/src/lang/tl-ph.json
@@ -146,7 +146,6 @@
 	"none": "None",
 	"small": "Small",
 	"large": "Large",
-	"floating button": "Floating button",
 	"confirm on exit": "I-confirm kapag mag-exit",
 	"show console": "Ipakita ang console",
 	"image": "Image",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Compact",
+	"off": "Off",
+	"quick tools height": "Quick tools height",
+	"quick tools toggler": "Quick tools toggler"
 }

--- a/src/lang/tr-tr.json
+++ b/src/lang/tr-tr.json
@@ -146,7 +146,6 @@
 	"none": "none",
 	"small": "small",
 	"large": "large",
-	"floating button": "Floating button",
 	"confirm on exit": "Confirm on exit",
 	"show console": "Show console",
 	"image": "Image",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Kompakt",
+	"off": "Kapalı",
+	"quick tools height": "Hızlı araçlar yüksekliği",
+	"quick tools toggler": "Hızlı araçlar değiştirici"
 }

--- a/src/lang/uk-ua.json
+++ b/src/lang/uk-ua.json
@@ -146,7 +146,6 @@
 	"none": "Нема",
 	"small": "Малий",
 	"large": "Великий",
-	"floating button": "Плаваюча кнопка",
 	"confirm on exit": "Підтверджувати вихід",
 	"show console": "Показати консоль",
 	"image": "Зображення",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Компактний",
+	"off": "Вимк",
+	"quick tools height": "Висота швидких інструментів",
+	"quick tools toggler": "Перемикач швидких інструментів"
 }

--- a/src/lang/uz-uz.json
+++ b/src/lang/uz-uz.json
@@ -146,7 +146,6 @@
 	"none": "none",
 	"small": "small",
 	"large": "large",
-	"floating button": "Floating button",
 	"confirm on exit": "Confirm on exit",
 	"show console": "Show console",
 	"image": "Image",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Compact",
+	"off": "Off",
+	"quick tools height": "Quick tools height",
+	"quick tools toggler": "Quick tools toggler"
 }

--- a/src/lang/vi-vn.json
+++ b/src/lang/vi-vn.json
@@ -146,7 +146,6 @@
 	"none": "Không có",
 	"small": "Nhỏ",
 	"large": "Lớn",
-	"floating button": "Nút nổi",
 	"confirm on exit": "Xác nhận khi thoát",
 	"show console": "Hiển thị bảng điều khiển",
 	"image": "Hình ảnh",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "Gọn",
+	"off": "Tắt",
+	"quick tools height": "Chiều cao công cụ nhanh",
+	"quick tools toggler": "Bật/tắt công cụ nhanh"
 }

--- a/src/lang/zh-cn.json
+++ b/src/lang/zh-cn.json
@@ -146,7 +146,6 @@
 	"none": "无",
 	"small": "小",
 	"large": "大",
-	"floating button": "悬浮按钮",
 	"confirm on exit": "退出前确认",
 	"show console": "显示控制台",
 	"image": "图像",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "紧凑",
+	"off": "关闭",
+	"quick tools height": "快捷工具栏高度",
+	"quick tools toggler": "快捷工具切换按钮"
 }

--- a/src/lang/zh-hant.json
+++ b/src/lang/zh-hant.json
@@ -146,7 +146,6 @@
 	"none": "無",
 	"small": "小",
 	"large": "大",
-	"floating button": "懸浮按鈕",
 	"confirm on exit": "退出前確認",
 	"show console": "顯示控製臺",
 	"image": "圖像",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "緊湊",
+	"off": "關閉",
+	"quick tools height": "快捷工具欄高度",
+	"quick tools toggler": "快捷工具切換按鈕"
 }

--- a/src/lang/zh-tw.json
+++ b/src/lang/zh-tw.json
@@ -146,7 +146,6 @@
 	"none": "無",
 	"small": "小",
 	"large": "大",
-	"floating button": "懸浮按鈕",
 	"confirm on exit": "退出前確認",
 	"show console": "顯示主控台",
 	"image": "圖片",
@@ -760,5 +759,9 @@
 	"scrollbar height": "Scrollbar height",
 	"full": "Full",
 	"scroll past end": "Scroll past end",
-	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top."
+	"settings-info-scroll-past-end": "Adds extra empty space at the bottom of the editor, allowing you to scroll the last line to the top.",
+	"compact": "緊湊",
+	"off": "關閉",
+	"quick tools height": "快捷工具列高度",
+	"quick tools toggler": "快捷工具列切換按鈕"
 }

--- a/src/lib/applySettings.js
+++ b/src/lib/applySettings.js
@@ -38,7 +38,7 @@ export default {
 			if (!$toggler.isConnected) {
 				root.appendOuter($toggler);
 			}
-		} else if ($toggler.isConnected) {
+		} else {
 			clearTimeout($toggler._hideTimeout);
 			$toggler.classList.add("hide");
 			$toggler._hideTimeout = setTimeout(() => {

--- a/src/lib/applySettings.js
+++ b/src/lib/applySettings.js
@@ -1,3 +1,4 @@
+import quickTools from "../components/quickTools";
 import actions from "../handlers/quickTools";
 import appSettings from "../lib/settings";
 import themes from "../theme/list";
@@ -29,8 +30,21 @@ export default {
 	},
 	afterRender() {
 		const { value: settings } = appSettings;
-		if (!settings.floatingButton) {
-			root.classList.add("hide-floating-button");
+		const { $toggler } = quickTools;
+		if (settings.floatingButton) {
+			clearTimeout($toggler._hideTimeout);
+			$toggler._hideTimeout = null;
+			$toggler.classList.remove("hide");
+			if (!$toggler.isConnected) {
+				root.appendOuter($toggler);
+			}
+		} else if ($toggler.isConnected) {
+			clearTimeout($toggler._hideTimeout);
+			$toggler.classList.add("hide");
+			$toggler._hideTimeout = setTimeout(() => {
+				$toggler.remove();
+				$toggler._hideTimeout = null;
+			}, 300);
 		}
 
 		actions("set-height", settings.quickTools);

--- a/src/lib/editorFile.js
+++ b/src/lib/editorFile.js
@@ -1360,13 +1360,11 @@ export default class EditorFile {
 		if (this.hideQuickTools) {
 			const { $toggler } = quickTools;
 			clearTimeout($toggler._hideTimeout);
-			if ($toggler.isConnected) {
-				$toggler.classList.add("hide");
-				$toggler._hideTimeout = setTimeout(() => {
-					$toggler.remove();
-					$toggler._hideTimeout = null;
-				}, 300);
-			}
+			$toggler.classList.add("hide");
+			$toggler._hideTimeout = setTimeout(() => {
+				$toggler.remove();
+				$toggler._hideTimeout = null;
+			}, 300);
 			actions("set-height", { height: 0, save: false });
 		} else {
 			const { $toggler } = quickTools;

--- a/src/lib/editorFile.js
+++ b/src/lib/editorFile.js
@@ -8,6 +8,7 @@ import {
 	setScrollPosition,
 } from "cm/editorUtils";
 import { getMode, getModeForPath } from "cm/modelist";
+import quickTools from "components/quickTools";
 import Sidebar from "components/sidebar";
 import tile from "components/tile";
 import toast from "components/toast";
@@ -1357,10 +1358,24 @@ export default class EditorFile {
 
 		// Handle quicktools visibility based on hideQuickTools property
 		if (this.hideQuickTools) {
-			root.classList.add("hide-floating-button");
+			const { $toggler } = quickTools;
+			clearTimeout($toggler._hideTimeout);
+			if ($toggler.isConnected) {
+				$toggler.classList.add("hide");
+				$toggler._hideTimeout = setTimeout(() => {
+					$toggler.remove();
+					$toggler._hideTimeout = null;
+				}, 300);
+			}
 			actions("set-height", { height: 0, save: false });
 		} else {
-			root.classList.remove("hide-floating-button");
+			const { $toggler } = quickTools;
+			clearTimeout($toggler._hideTimeout);
+			$toggler._hideTimeout = null;
+			$toggler.classList.remove("hide");
+			if (appSettings.value.floatingButton && !$toggler.isConnected) {
+				root.appendOuter($toggler);
+			}
 			const quickToolsHeight =
 				appSettings.value.quickTools !== undefined
 					? appSettings.value.quickTools

--- a/src/lib/editorFile.js
+++ b/src/lib/editorFile.js
@@ -1370,11 +1370,13 @@ export default class EditorFile {
 			actions("set-height", { height: 0, save: false });
 		} else {
 			const { $toggler } = quickTools;
-			clearTimeout($toggler._hideTimeout);
-			$toggler._hideTimeout = null;
-			$toggler.classList.remove("hide");
-			if (appSettings.value.floatingButton && !$toggler.isConnected) {
-				root.appendOuter($toggler);
+			if (appSettings.value.floatingButton) {
+				clearTimeout($toggler._hideTimeout);
+				$toggler._hideTimeout = null;
+				$toggler.classList.remove("hide");
+				if (!$toggler.isConnected) {
+					root.appendOuter($toggler);
+				}
 			}
 			const quickToolsHeight =
 				appSettings.value.quickTools !== undefined

--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -2026,6 +2026,10 @@ async function EditorManager($header, $body) {
 			const file = manager.activeFile;
 			if (!file || file.type !== "editor") return;
 
+			if (update.docChanged) {
+				events.emit("editor-state-changed", update.view);
+			}
+
 			// Only run expensive work when the document actually changed
 			if (!update.docChanged) return;
 

--- a/src/lib/settings.js
+++ b/src/lib/settings.js
@@ -86,7 +86,6 @@ class Settings {
 		"**/.DS_Store/**",
 		"**/Thumbs.db/**",
 	];
-	#IS_TABLET = innerWidth > 768;
 
 	QUICKTOOLS_ROWS = 2;
 	QUICKTOOLS_GROUP_CAPACITY = 8;
@@ -143,13 +142,13 @@ class Settings {
 			fadeFoldWidgets: false,
 			autoCorrect: true,
 			openFileListPos: this.OPEN_FILE_LIST_POS_HEADER,
-			quickTools: this.#IS_TABLET ? 0 : 1,
+			quickTools: 2,
 			quickToolsTriggerMode: this.QUICKTOOLS_TRIGGER_MODE_TOUCH,
 			appFont: "",
 			editorFont: "Roboto Mono",
 			vibrateOnTap: true,
 			fullscreen: false,
-			floatingButton: !this.#IS_TABLET,
+			floatingButton: false,
 			liveAutoCompletion: true,
 			localWordCompletion: true,
 			autoIndent: true,
@@ -187,7 +186,10 @@ class Settings {
 			hardWrap: false,
 			useTextareaForIME: false,
 			touchMoveThreshold: Math.round((1 / devicePixelRatio) * 10) / 20,
-			quicktoolsItems: [...Array(this.#QUICKTOOLS_SIZE).keys()],
+			quicktoolsItems: [
+				2, 1, 34, 3, 4, 18, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 33, 21, 20,
+				16, 19, 17, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+			],
 			excludeFolders: this.#excludeFolders,
 			defaultFileEncoding: "UTF-8",
 			inlineAutoCompletion: true,

--- a/src/settings/appSettings.js
+++ b/src/settings/appSettings.js
@@ -443,7 +443,7 @@ export default function otherSettings() {
 					if (!quickTools.$toggler.isConnected) {
 						root.appendOuter(quickTools.$toggler);
 					}
-				} else if (quickTools.$toggler.isConnected) {
+				} else {
 					clearTimeout(quickTools.$toggler._hideTimeout);
 					quickTools.$toggler.classList.add("hide");
 					quickTools.$toggler._hideTimeout = setTimeout(() => {

--- a/src/settings/appSettings.js
+++ b/src/settings/appSettings.js
@@ -159,8 +159,9 @@ export default function otherSettings() {
 			text: strings["quick tools height"],
 			value: values.quickTools,
 			valueText: (value) => {
-				if (value === 0) return strings.off;
-				if (value === 1) return strings.compact;
+				const height = Number(value) || 0;
+				if (height === 0) return strings.off;
+				if (height === 1) return strings.compact;
 				return strings.full;
 			},
 			select: [

--- a/src/settings/appSettings.js
+++ b/src/settings/appSettings.js
@@ -187,7 +187,7 @@ export default function otherSettings() {
 				},
 			},
 			info: strings["settings-info-app-touch-move-threshold"],
-			category: categories.quickTools,
+			category: categories.interface,
 		},
 		{
 			key: "appFont",

--- a/src/settings/appSettings.js
+++ b/src/settings/appSettings.js
@@ -1,5 +1,6 @@
 import fsOperation from "fileSystem";
 import { resetKeyBindings } from "cm/commandRegistry";
+import quickTools from "components/quickTools";
 import settingsPage from "components/settingsPage";
 import loader from "dialogs/loader";
 import select from "dialogs/select";
@@ -29,6 +30,7 @@ export default function otherSettings() {
 		fonts: strings["settings-category-fonts"],
 		filesSessions: strings["settings-category-files-sessions"],
 		advanced: strings["settings-category-advanced"],
+		quickTools: strings["quick tools"],
 	};
 	const items = [
 		{
@@ -105,13 +107,6 @@ export default function otherSettings() {
 			category: categories.interface,
 		},
 		{
-			key: "floatingButton",
-			text: strings["floating button"],
-			checkbox: values.floatingButton,
-			info: strings["settings-info-app-floating-button"],
-			category: categories.interface,
-		},
-		{
 			key: "showSideButtons",
 			text: strings["show side buttons"],
 			checkbox: values.showSideButtons,
@@ -139,11 +134,28 @@ export default function otherSettings() {
 			category: categories.interface,
 		},
 		{
+			key: "floatingButton",
+			text: strings["quick tools toggler"],
+			checkbox: values.floatingButton,
+			info: strings["settings-info-app-floating-button"],
+			category: categories.quickTools,
+		},
+		{
 			key: "quickTools",
-			text: strings["quick tools"],
-			checkbox: !!values.quickTools,
+			text: strings["quick tools height"],
+			value: values.quickTools,
+			valueText: (value) => {
+				if (value === 0) return strings.off;
+				if (value === 1) return strings.compact;
+				return strings.full;
+			},
+			select: [
+				[0, strings.off],
+				[1, strings.compact],
+				[2, strings.full],
+			],
 			info: strings["info-quickTools"],
-			category: categories.interface,
+			category: categories.quickTools,
 		},
 		{
 			key: "quickToolsTriggerMode",
@@ -154,13 +166,13 @@ export default function otherSettings() {
 				[appSettings.QUICKTOOLS_TRIGGER_MODE_TOUCH, "touch"],
 			],
 			info: strings["settings-info-app-quick-tools-trigger-mode"],
-			category: categories.interface,
+			category: categories.quickTools,
 		},
 		{
 			key: "quickToolsSettings",
 			text: strings["shortcut buttons"],
 			info: strings["settings-info-app-quick-tools-settings"],
-			category: categories.interface,
+			category: categories.quickTools,
 			chevron: true,
 		},
 		{
@@ -175,7 +187,7 @@ export default function otherSettings() {
 				},
 			},
 			info: strings["settings-info-app-touch-move-threshold"],
-			category: categories.interface,
+			category: categories.quickTools,
 		},
 		{
 			key: "appFont",
@@ -423,7 +435,21 @@ export default function otherSettings() {
 				break;
 
 			case "floatingButton":
-				root.classList.toggle("hide-floating-button");
+				if (value) {
+					clearTimeout(quickTools.$toggler._hideTimeout);
+					quickTools.$toggler._hideTimeout = null;
+					quickTools.$toggler.classList.remove("hide");
+					if (!quickTools.$toggler.isConnected) {
+						root.appendOuter(quickTools.$toggler);
+					}
+				} else if (quickTools.$toggler.isConnected) {
+					clearTimeout(quickTools.$toggler._hideTimeout);
+					quickTools.$toggler.classList.add("hide");
+					quickTools.$toggler._hideTimeout = setTimeout(() => {
+						quickTools.$toggler.remove();
+						quickTools.$toggler._hideTimeout = null;
+					}, 300);
+				}
 				break;
 
 			case "keyboardMode":
@@ -442,14 +468,9 @@ export default function otherSettings() {
 				break;
 
 			case "quickTools":
-				if (value) {
-					value = 1;
-					actions("set-height", 1);
-				} else {
-					value = 0;
-					actions("set-height", 0);
-				}
-				break;
+				value = Number(value) || 0;
+				actions("set-height", value);
+				return;
 
 			case "excludeFolders":
 				value = value
@@ -462,7 +483,7 @@ export default function otherSettings() {
 				break;
 		}
 
-		appSettings.update({
+		await appSettings.update({
 			[key]: value,
 		});
 	}

--- a/src/settings/appSettings.js
+++ b/src/settings/appSettings.js
@@ -471,8 +471,8 @@ export default function otherSettings() {
 
 			case "quickTools":
 				value = Number(value) || 0;
-				actions("set-height", value);
-				return;
+				actions("set-height", { height: value, save: false });
+				break;
 
 			case "excludeFolders":
 				value = value

--- a/src/settings/appSettings.js
+++ b/src/settings/appSettings.js
@@ -134,6 +134,20 @@ export default function otherSettings() {
 			category: categories.interface,
 		},
 		{
+			key: "touchMoveThreshold",
+			text: strings["touch move threshold"],
+			value: values.touchMoveThreshold,
+			prompt: strings["touch move threshold"],
+			promptType: "number",
+			promptOptions: {
+				test(value) {
+					return value >= 0;
+				},
+			},
+			info: strings["settings-info-app-touch-move-threshold"],
+			category: categories.interface,
+		},
+		{
 			key: "floatingButton",
 			text: strings["quick tools toggler"],
 			checkbox: values.floatingButton,
@@ -161,9 +175,10 @@ export default function otherSettings() {
 			key: "quickToolsTriggerMode",
 			text: strings["quicktools trigger mode"],
 			value: values.quickToolsTriggerMode,
+			valueText: (value) => value.capitalize(),
 			select: [
-				[appSettings.QUICKTOOLS_TRIGGER_MODE_CLICK, "click"],
-				[appSettings.QUICKTOOLS_TRIGGER_MODE_TOUCH, "touch"],
+				[appSettings.QUICKTOOLS_TRIGGER_MODE_CLICK, "Click"],
+				[appSettings.QUICKTOOLS_TRIGGER_MODE_TOUCH, "Touch"],
 			],
 			info: strings["settings-info-app-quick-tools-trigger-mode"],
 			category: categories.quickTools,
@@ -174,20 +189,6 @@ export default function otherSettings() {
 			info: strings["settings-info-app-quick-tools-settings"],
 			category: categories.quickTools,
 			chevron: true,
-		},
-		{
-			key: "touchMoveThreshold",
-			text: strings["touch move threshold"],
-			value: values.touchMoveThreshold,
-			prompt: strings["touch move threshold"],
-			promptType: "number",
-			promptOptions: {
-				test(value) {
-					return value >= 0;
-				},
-			},
-			info: strings["settings-info-app-touch-move-threshold"],
-			category: categories.interface,
 		},
 		{
 			key: "appFont",


### PR DESCRIPTION
- Replace quickTools true/false checkbox with Off/Compact/Full (0/1/2) height selector
- Move floatingButton and quickTools settings into dedicated "Quick Tools" settings category
- Manage $toggler element dynamically via appendOuter/remove instead of CSS class toggle (hide-floating-button)
- Add 4 translation keys ("compact", "off", "quick tools height", "quick tools toggler") across all 32 language files
- Update default quicktoolsItems ordering

Bug fixes:
- Cancel pending .hide timeout before re-appending toggler to prevent race condition removal after re-connect
- Remove .hide class on re-append to prevent invisible toggler (opacity: 0 !important)
- Coerce legacy boolean quickTools values to number for select handler
- fix state sync on settings page in search mode
- fix search panel behaviour on switching the tab

- Keep undo/redo disabled when there is nothing to undo/redo
- add paste command to add in quicktools