### PR TITLE
Fixes several small querks and inconsistencies to improve UI/UX

### DIFF
--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -435,6 +435,7 @@ function create($container, $toggler) {
 	}
 
 	async function onshow() {
+		hideEditorNativeSelectionHandles();
 		if ($el.onshow) $el.onshow.call($el);
 		events.show.forEach((fn) => fn());
 
@@ -453,6 +454,23 @@ function create($container, $toggler) {
 	function onhide() {
 		if ($el.onhide) $el.onhide.call($el);
 		events.hide.forEach((fn) => fn());
+	}
+
+	function hideEditorNativeSelectionHandles() {
+		const editor = window.editorManager?.editor;
+		if (!editor) return;
+
+		try {
+			editor.contentDOM?.blur();
+		} catch (_) {
+			// Ignore focus cleanup failures; clearing DOM selection below is best-effort.
+		}
+
+		try {
+			document.getSelection()?.removeAllRanges();
+		} catch (error) {
+			console.warn("Failed to clear native text selection.", error);
+		}
 	}
 
 	/**

--- a/src/handlers/keyboard.js
+++ b/src/handlers/keyboard.js
@@ -187,14 +187,24 @@ function emit(eventName) {
 }
 
 /**
- * Focus the editor if keyboard is visible, blur it otherwise.
+ * Blur regular inputs when the soft keyboard is dismissed.
+ * Keep CodeMirror focused so its cursor remains visible after keyboard close.
  * @param {boolean} keyboardHidden
  * @returns
  */
 function focusBlurEditor(keyboardHidden) {
-	if (keyboardHidden) {
-		document.activeElement?.blur();
+	if (!keyboardHidden) return;
+
+	const activeElement = document.activeElement;
+	const editorContent = window.editorManager?.editor?.contentDOM;
+	if (
+		editorContent &&
+		(activeElement === editorContent || editorContent.contains(activeElement))
+	) {
+		return;
 	}
+
+	activeElement?.blur();
 }
 
 /**

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -65,8 +65,12 @@ function resolveReferenceFile(referenceFile) {
 	return referenceFile;
 }
 
-function canSaveFile(file = editorManager.activeFile) {
-	return file?.type === "editor" && typeof file.save === "function";
+export function canSaveFile(file = editorManager.activeFile) {
+	return (
+		file?.type === "editor" &&
+		typeof file.save === "function" &&
+		typeof file.saveAs === "function"
+	);
 }
 
 function getTabsRelativeToFile(side, referenceFile) {
@@ -360,8 +364,7 @@ export default {
 	async "save-as"(showToast) {
 		try {
 			const { activeFile } = editorManager;
-			if (!canSaveFile(activeFile) || typeof activeFile.saveAs !== "function")
-				return;
+			if (!canSaveFile(activeFile)) return;
 			await activeFile.saveAs();
 			if (showToast) {
 				toast(strings["file saved"]);

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -65,6 +65,10 @@ function resolveReferenceFile(referenceFile) {
 	return referenceFile;
 }
 
+function canSaveFile(file = editorManager.activeFile) {
+	return file?.type === "editor" && typeof file.save === "function";
+}
+
 function getTabsRelativeToFile(side, referenceFile) {
 	const { files } = editorManager;
 	const file = resolveReferenceFile(referenceFile);
@@ -343,7 +347,9 @@ export default {
 	},
 	async save(showToast) {
 		try {
-			await editorManager.activeFile.save();
+			const { activeFile } = editorManager;
+			if (!canSaveFile(activeFile)) return;
+			await activeFile.save();
 			if (showToast) {
 				toast(strings["file saved"]);
 			}
@@ -353,7 +359,10 @@ export default {
 	},
 	async "save-as"(showToast) {
 		try {
-			await editorManager.activeFile.saveAs();
+			const { activeFile } = editorManager;
+			if (!canSaveFile(activeFile) || typeof activeFile.saveAs !== "function")
+				return;
+			await activeFile.saveAs();
 			if (showToast) {
 				toast(strings["file saved"]);
 			}

--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -2307,6 +2307,12 @@ async function EditorManager($header, $body) {
 			if (isCursorRevealSuppressed()) return;
 			scrollCursorIntoView();
 		});
+		keyboardHandler.on("keyboardHide", () => {
+			requestAnimationFrame(() => {
+				if (isCursorRevealSuppressed()) return;
+				scrollCursorIntoView({ behavior: "instant" });
+			});
+		});
 
 		// Attach native DOM event listeners directly to the editor's contentDOM
 		const contentDOM = editor.contentDOM;

--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,7 @@ import ajax from "lib/ajax";
 import applySettings from "lib/applySettings";
 import checkFiles from "lib/checkFiles";
 import checkPluginsUpdate from "lib/checkPluginsUpdate";
+import { canSaveFile } from "lib/commands";
 import config from "lib/config";
 import EditorFile from "lib/editorFile";
 import EditorManager from "lib/editorManager";
@@ -772,7 +773,7 @@ function createMainMenu({ top, bottom, toggler }) {
 		innerHTML: () => {
 			return mustache.render($_menu, {
 				...strings,
-				can_save_file: window.editorManager?.activeFile?.type === "editor",
+				can_save_file: canSaveFile(window.editorManager?.activeFile),
 			});
 		},
 	});

--- a/src/main.js
+++ b/src/main.js
@@ -770,7 +770,10 @@ function createMainMenu({ top, bottom, toggler }) {
 		toggler,
 		transformOrigin: top ? "top right" : "bottom right",
 		innerHTML: () => {
-			return mustache.render($_menu, strings);
+			return mustache.render($_menu, {
+				...strings,
+				can_save_file: window.editorManager?.activeFile?.type === "editor",
+			});
 		},
 	});
 }

--- a/src/sidebarApps/index.js
+++ b/src/sidebarApps/index.js
@@ -20,7 +20,7 @@ let $sponsorIcon = null;
  * @param {string} id id of the app
  * @param {HTMLElement} el element to show in sidebar
  * @param {string} title title of the app
- * @param {(container:HTMLElement)=>void} initFunction
+ * @param {(container:HTMLElement)=>(void|Function)} initFunction
  * @param {boolean} prepend weather to show this app at the top of the sidebar or not
  * @param {(container:HTMLElement)=>void} onSelected
  * @returns {void}

--- a/src/sidebarApps/searchInFiles/cmResultView.js
+++ b/src/sidebarApps/searchInFiles/cmResultView.js
@@ -414,6 +414,18 @@ export function createSearchResultView(
 			isGhostText = false;
 			this.setValue("");
 		},
+		getScrollPosition() {
+			return {
+				top: view.scrollDOM?.scrollTop || 0,
+				left: view.scrollDOM?.scrollLeft || 0,
+			};
+		},
+		setScrollPosition({ top = 0, left = 0 } = {}) {
+			const scroller = view.scrollDOM;
+			if (!scroller) return;
+			scroller.scrollTop = top;
+			scroller.scrollLeft = left;
+		},
 		get view() {
 			return view;
 		},

--- a/src/sidebarApps/searchInFiles/cmResultView.js
+++ b/src/sidebarApps/searchInFiles/cmResultView.js
@@ -416,8 +416,8 @@ export function createSearchResultView(
 		},
 		getScrollPosition() {
 			return {
-				top: view.scrollDOM?.scrollTop || 0,
-				left: view.scrollDOM?.scrollLeft || 0,
+				top: view.scrollDOM?.scrollTop ?? 0,
+				left: view.scrollDOM?.scrollLeft ?? 0,
 			};
 		},
 		setScrollPosition({ top = 0, left = 0 } = {}) {

--- a/src/sidebarApps/searchInFiles/index.js
+++ b/src/sidebarApps/searchInFiles/index.js
@@ -155,8 +155,6 @@ preventSlide((target) => {
 	return $container.el?.contains(target);
 });
 
-Sidebar.on("show", restoreResultScroll);
-
 function toggleReplace() {
 	showReplace = !showReplace;
 	$headerEl.el.classList.toggle("show-replace", showReplace);
@@ -181,6 +179,7 @@ export default [
 	strings["search in files"],
 	(/**@type {HTMLElement} */ el) => {
 		el.classList.add("search-in-files");
+		Sidebar.on("show", restoreResultScroll);
 
 		el.content = (
 			<>
@@ -289,6 +288,7 @@ export default [
 				></div>
 			</>
 		);
+		return () => Sidebar.off("show", restoreResultScroll);
 	},
 	false, // show as first item
 	() => {},

--- a/src/sidebarApps/searchInFiles/index.js
+++ b/src/sidebarApps/searchInFiles/index.js
@@ -545,8 +545,12 @@ function onInput(e) {
 	resetResultScroll();
 	clearPendingResultText();
 	searchResult.setValue("");
-	searchResult.setGhostText(strings["searching..."], { row: 0, column: 0 });
 	removeEvents();
+	if (!$search.value) {
+		searchResult.removeGhostText();
+		return;
+	}
+	searchResult.setGhostText(strings["searching..."], { row: 0, column: 0 });
 	debounceSearch();
 }
 

--- a/src/sidebarApps/searchInFiles/index.js
+++ b/src/sidebarApps/searchInFiles/index.js
@@ -106,6 +106,9 @@ let useIncludeAndExclude = showExtras;
 const $headerEl = Ref();
 let searchResult = null; // CM6 wrapper from createSearchResultView
 let currentSearchRegex = null;
+let resultScrollTop = 0;
+let resultScrollLeft = 0;
+let resultScrollRestoreFrame = 0;
 let replacing = false;
 let newFiles = 0;
 let searching = false;
@@ -137,12 +140,22 @@ $container.onref = ($el) => {
 		getFileNames: () => fileNames,
 		getRegex: () => currentSearchRegex,
 	});
+	searchResult.view.scrollDOM?.addEventListener(
+		"scroll",
+		rememberResultScroll,
+		{
+			passive: true,
+		},
+	);
+	restoreResultScroll();
 	$container.style.lineHeight = "1.5";
 };
 
 preventSlide((target) => {
 	return $container.el?.contains(target);
 });
+
+Sidebar.on("show", restoreResultScroll);
 
 function toggleReplace() {
 	showReplace = !showReplace;
@@ -529,6 +542,7 @@ function onInput(e) {
 	$progress.value = 0;
 	filesSearched.length = 0;
 	resultOverview.reset();
+	resetResultScroll();
 	clearPendingResultText();
 	searchResult.setValue("");
 	searchResult.setGhostText(strings["searching..."], { row: 0, column: 0 });
@@ -1008,6 +1022,7 @@ async function onCursorChange(line) {
 		return;
 	}
 
+	rememberResultScroll();
 	Sidebar.hide();
 	const { url } = filesSearched[file];
 	await openFile(url, { render: true });
@@ -1042,6 +1057,31 @@ function onEditorFileUpdate(file) {
 	const uri = file?.uri;
 	if (uri) markIndexDirty([uri]);
 	onInput();
+}
+
+function rememberResultScroll() {
+	const position = searchResult?.getScrollPosition?.();
+	if (!position) return;
+	resultScrollTop = position.top;
+	resultScrollLeft = position.left;
+}
+
+function restoreResultScroll() {
+	cancelAnimationFrame(resultScrollRestoreFrame);
+	resultScrollRestoreFrame = requestAnimationFrame(() => {
+		resultScrollRestoreFrame = 0;
+		searchResult?.setScrollPosition?.({
+			top: resultScrollTop,
+			left: resultScrollLeft,
+		});
+	});
+}
+
+function resetResultScroll() {
+	resultScrollTop = 0;
+	resultScrollLeft = 0;
+	cancelAnimationFrame(resultScrollRestoreFrame);
+	resultScrollRestoreFrame = 0;
 }
 
 /**

--- a/src/sidebarApps/searchInFiles/styles.scss
+++ b/src/sidebarApps/searchInFiles/styles.scss
@@ -20,18 +20,24 @@
       display: flex;
       justify-content: space-between !important;
       align-items: center;
+      gap: 8px;
       width: 100%;
       color: var(--primary-text-color);
       margin-bottom: 8px;
 
       .title-text {
         font-size: 0.9rem;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
 
       .actions {
         display: flex;
         align-items: center;
         gap: 6px;
+        flex: 0 0 auto;
       }
 
       .icon-button {
@@ -61,14 +67,31 @@
       }
     }
 
-    /* Options Row (Original Right-Aligned Checkboxes) */
     .options {
-      display: flex;
-      justify-content: center;
-      gap: 16px;
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
       width: 100%;
       margin-bottom: 10px;
       flex-shrink: 0;
+
+      .input-checkbox {
+        min-width: 0;
+        justify-content: center;
+        white-space: nowrap;
+
+        .box {
+          flex: 0 0 auto;
+          margin: 0 5px 0 0;
+        }
+
+        >span:last-child {
+          min-width: 0;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+      }
     }
 
     /* Input Rows */

--- a/src/sidebarApps/sidebarApp.js
+++ b/src/sidebarApps/sidebarApp.js
@@ -10,7 +10,7 @@ export default class SidebarApp {
 	#icon;
 	/**@type {string} */
 	#id;
-	/**@type {string} */
+	/**@type {(el:HTMLElement)=>(void|Function)} */
 	#init;
 	/**@type {string} */
 	#title;
@@ -18,6 +18,8 @@ export default class SidebarApp {
 	#active;
 	/**@type {(el:HTMLElement)=>void} */
 	#onselect;
+	/**@type {Function|null} */
+	#cleanup = null;
 	/**@type {HTMLElement} */
 	#container;
 
@@ -26,7 +28,7 @@ export default class SidebarApp {
 	 * @param {string} icon
 	 * @param {string} id
 	 * @param {string} title
-	 * @param {(el:HTMLElement)=>void} init
+	 * @param {(el:HTMLElement)=>(void|Function)} init
 	 * @param {(el:HTMLElement)=>void} onselect
 	 */
 	constructor(icon, id, title, init, onselect) {
@@ -37,7 +39,10 @@ export default class SidebarApp {
 		this.#title = title;
 		this.#init = init || emptyFunc;
 		this.#onselect = onselect || emptyFunc;
-		this.#init(this.#container);
+		const cleanup = this.#init(this.#container);
+		if (typeof cleanup === "function") {
+			this.#cleanup = cleanup;
+		}
 	}
 
 	/**
@@ -135,6 +140,8 @@ export default class SidebarApp {
 	}
 
 	remove() {
+		this.#cleanup?.();
+		this.#cleanup = null;
 		if (this.#icon) {
 			this.#icon.remove();
 			this.#icon = null;

--- a/src/views/menu.hbs
+++ b/src/views/menu.hbs
@@ -2,11 +2,11 @@
   <span class="text">{{new file}}</span>
   <span class="icon file-control document-add"></span>
 </li>
-<li action="save">
+<li action="save" {{^can_save_file}}class="disabled" {{/can_save_file}}>
   <span class="text">{{save}}</span>
   <span class="icon save"></span>
 </li>
-<li action="save-as">
+<li action="save-as" {{^can_save_file}}class="disabled" {{/can_save_file}}>
   <span class="text">{{save as}}</span>
   <span class="icon save" style="filter: brightness(85%)"></span>
 </li>


### PR DESCRIPTION
- fix: hide selection handles when sidebar opened instead of overlaying(Fixes: #2321)
- feat: scroll preservation for project-wide search results(Fixes: #2324)
- fix: don't show searching status early in project wide search(Fixes: #2312)
- fix:the project-wide search header/options layout to shrink on small screen(Fixes: #2310)
- skips explicit blur when the active element is CodeMirror’s contentDOM (Fixes: #2296)
- fix: disable save, save as in the main menu unless the active tab is a real editor file tab