### PR TITLE
feat(keybind): add code folds keybinds

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,5 +197,10 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.43.1"
   },
-  "browserslist": "cover 100%"
+  "browserslist": "cover 100%",
+  "allowScripts": {
+    "@parcel/watcher@2.5.6": true,
+    "core-js@3.49.0": true,
+    "core-js-pure@3.49.0": true
+  }
 }

--- a/src/cm/commandRegistry.js
+++ b/src/cm/commandRegistry.js
@@ -53,7 +53,13 @@ import {
 	toggleBlockComment,
 	undo,
 } from "@codemirror/commands";
-import { foldAll, foldCode, indentUnit as indentUnitFacet, unfoldAll, unfoldCode } from "@codemirror/language";
+import {
+	foldAll,
+	foldCode,
+	indentUnit as indentUnitFacet,
+	unfoldAll,
+	unfoldCode,
+} from "@codemirror/language";
 import {
 	closeLintPanel,
 	forceLinting,
@@ -955,7 +961,7 @@ function registerCoreCommands() {
 			const resolvedView = resolveView(view);
 			if (!resolvedView) return false;
 			return foldCode(resolvedView);
-		}
+		},
 	});
 	addCommand({
 		name: "unfoldCode",
@@ -966,18 +972,19 @@ function registerCoreCommands() {
 			const resolvedView = resolveView(view);
 			if (!resolvedView) return false;
 			return unfoldCode(resolvedView);
-		}
+		},
 	});
 	addCommand({
 		name: "foldAll",
-		description: "Fold all - top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
+		description:
+			"Fold all - top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
 		readOnly: false,
 		requiresView: true,
 		run(view) {
 			const resolvedView = resolveView(view);
 			if (!resolvedView) return false;
 			return foldAll(resolvedView);
-		}
+		},
 	});
 	addCommand({
 		name: "unfoldAll",
@@ -988,7 +995,7 @@ function registerCoreCommands() {
 			const resolvedView = resolveView(view);
 			if (!resolvedView) return false;
 			return unfoldAll(resolvedView);
-		}
+		},
 	});
 }
 

--- a/src/cm/commandRegistry.js
+++ b/src/cm/commandRegistry.js
@@ -53,7 +53,7 @@ import {
 	toggleBlockComment,
 	undo,
 } from "@codemirror/commands";
-import { indentUnit as indentUnitFacet } from "@codemirror/language";
+import { foldAll, foldCode, indentUnit as indentUnitFacet, unfoldAll, unfoldCode } from "@codemirror/language";
 import {
 	closeLintPanel,
 	forceLinting,
@@ -945,6 +945,50 @@ function registerCoreCommands() {
 			if (!resolvedView) return false;
 			return simplifySelection(resolvedView);
 		},
+	});
+	addCommand({
+		name: "foldCode",
+		description: "Fold the Lines that are selected (if possible)",
+		readOnly: false,
+		requiresView: true,
+		run(view) {
+			const resolvedView = resolveView(view);
+			if (!resolvedView) return false;
+			return foldCode(resolvedView);
+		}
+	});
+	addCommand({
+		name: "unfoldCode",
+		description: "Unfold folded ranges on selected lines.",
+		readOnly: false,
+		requiresView: true,
+		run(view) {
+			const resolvedView = resolveView(view);
+			if (!resolvedView) return false;
+			return unfoldCode(resolvedView);
+		}
+	});
+	addCommand({
+		name: "foldAll",
+		description: "Fold all - top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
+		readOnly: false,
+		requiresView: true,
+		run(view) {
+			const resolvedView = resolveView(view);
+			if (!resolvedView) return false;
+			return foldAll(resolvedView);
+		}
+	});
+	addCommand({
+		name: "unfoldAll",
+		description: "Unfold all folded code.",
+		readOnly: false,
+		requiresView: true,
+		run(view) {
+			const resolvedView = resolveView(view);
+			if (!resolvedView) return false;
+			return unfoldAll(resolvedView);
+		}
 	});
 }
 

--- a/src/cm/commandRegistry.js
+++ b/src/cm/commandRegistry.js
@@ -955,7 +955,7 @@ function registerCoreCommands() {
 	addCommand({
 		name: "foldCode",
 		description: "Fold the Lines that are selected (if possible)",
-		readOnly: false,
+		readOnly: true,
 		requiresView: true,
 		run(view) {
 			const resolvedView = resolveView(view);
@@ -966,7 +966,7 @@ function registerCoreCommands() {
 	addCommand({
 		name: "unfoldCode",
 		description: "Unfold folded ranges on selected lines.",
-		readOnly: false,
+		readOnly: true,
 		requiresView: true,
 		run(view) {
 			const resolvedView = resolveView(view);
@@ -978,7 +978,7 @@ function registerCoreCommands() {
 		name: "foldAll",
 		description:
 			"Fold all - top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
-		readOnly: false,
+		readOnly: true,
 		requiresView: true,
 		run(view) {
 			const resolvedView = resolveView(view);
@@ -989,7 +989,7 @@ function registerCoreCommands() {
 	addCommand({
 		name: "unfoldAll",
 		description: "Unfold all folded code.",
-		readOnly: false,
+		readOnly: true,
 		requiresView: true,
 		run(view) {
 			const resolvedView = resolveView(view);

--- a/src/lib/keyBindings.js
+++ b/src/lib/keyBindings.js
@@ -533,7 +533,7 @@ const APP_BINDING_CONFIG = [
 	},
 	{
 		name: "foldAll",
-		description: "Folding all top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
+		description: "Fold all - top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
 		key: "Ctrl-Alt-[",
 		readOnly: false,
 		editorOnly: true,

--- a/src/lib/keyBindings.js
+++ b/src/lib/keyBindings.js
@@ -644,7 +644,6 @@ function buildCodemirrorKeyBindings(appBindings) {
 	}
 
 	const result = {};
-	console.log("comboMap", comboMap);
 	for (const [name, combos] of comboMap.entries()) {
 		if (!combos.size || appBindings[name]) continue;
 		result[name] = {

--- a/src/lib/keyBindings.js
+++ b/src/lib/keyBindings.js
@@ -533,7 +533,8 @@ const APP_BINDING_CONFIG = [
 	},
 	{
 		name: "foldAll",
-		description: "Fold all - top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
+		description:
+			"Fold all - top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
 		key: "Ctrl-Alt-[",
 		readOnly: false,
 		editorOnly: true,
@@ -544,7 +545,7 @@ const APP_BINDING_CONFIG = [
 		key: "Ctrl-Alt-]",
 		readOnly: false,
 		editorOnly: true,
-	}
+	},
 ];
 
 const APP_KEY_BINDINGS = buildAppBindings(APP_BINDING_CONFIG);
@@ -617,7 +618,7 @@ function buildCodemirrorKeyBindings(appBindings) {
 	const comboMap = new Map();
 
 	for (const binding of KEYMAP_SOURCES) {
-		console.log(binding)
+		console.log(binding);
 		const baseCombos = new Set();
 
 		pushCommandCombo(binding.run, binding.key, "win", baseCombos);
@@ -644,7 +645,7 @@ function buildCodemirrorKeyBindings(appBindings) {
 	}
 
 	const result = {};
-	console.log("comboMap", comboMap)
+	console.log("comboMap", comboMap);
 	for (const [name, combos] of comboMap.entries()) {
 		if (!combos.size || appBindings[name]) continue;
 		result[name] = {
@@ -656,7 +657,7 @@ function buildCodemirrorKeyBindings(appBindings) {
 			editorOnly: true,
 		};
 	}
-	console.log("result", result)
+	console.log("result", result);
 	return result;
 
 	function pushCommandCombo(commandFn, key, platform, baseCombos) {

--- a/src/lib/keyBindings.js
+++ b/src/lib/keyBindings.js
@@ -517,6 +517,34 @@ const APP_BINDING_CONFIG = [
 		editorOnly: true,
 		action: "format",
 	},
+	{
+		name: "foldCode",
+		description: "Fold code",
+		key: "Ctrl-Shift-[",
+		readOnly: false,
+		editorOnly: true,
+	},
+	{
+		name: "unfoldCode",
+		description: "Unfold code",
+		key: "Ctrl-Shift-]",
+		readOnly: false,
+		editorOnly: true,
+	},
+	{
+		name: "foldAll",
+		description: "Folding all top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
+		key: "Ctrl-Alt-[",
+		readOnly: false,
+		editorOnly: true,
+	},
+	{
+		name: "unfoldAll",
+		description: "Unfold all folded code",
+		key: "Ctrl-Alt-]",
+		readOnly: false,
+		editorOnly: true,
+	}
 ];
 
 const APP_KEY_BINDINGS = buildAppBindings(APP_BINDING_CONFIG);
@@ -589,6 +617,7 @@ function buildCodemirrorKeyBindings(appBindings) {
 	const comboMap = new Map();
 
 	for (const binding of KEYMAP_SOURCES) {
+		console.log(binding)
 		const baseCombos = new Set();
 
 		pushCommandCombo(binding.run, binding.key, "win", baseCombos);
@@ -615,6 +644,7 @@ function buildCodemirrorKeyBindings(appBindings) {
 	}
 
 	const result = {};
+	console.log("comboMap", comboMap)
 	for (const [name, combos] of comboMap.entries()) {
 		if (!combos.size || appBindings[name]) continue;
 		result[name] = {
@@ -626,6 +656,7 @@ function buildCodemirrorKeyBindings(appBindings) {
 			editorOnly: true,
 		};
 	}
+	console.log("result", result)
 	return result;
 
 	function pushCommandCombo(commandFn, key, platform, baseCombos) {

--- a/src/lib/keyBindings.js
+++ b/src/lib/keyBindings.js
@@ -618,7 +618,6 @@ function buildCodemirrorKeyBindings(appBindings) {
 	const comboMap = new Map();
 
 	for (const binding of KEYMAP_SOURCES) {
-		console.log(binding);
 		const baseCombos = new Set();
 
 		pushCommandCombo(binding.run, binding.key, "win", baseCombos);

--- a/src/lib/keyBindings.js
+++ b/src/lib/keyBindings.js
@@ -655,7 +655,6 @@ function buildCodemirrorKeyBindings(appBindings) {
 			editorOnly: true,
 		};
 	}
-	console.log("result", result);
 	return result;
 
 	function pushCommandCombo(commandFn, key, platform, baseCombos) {

--- a/src/lib/keyBindings.js
+++ b/src/lib/keyBindings.js
@@ -521,14 +521,14 @@ const APP_BINDING_CONFIG = [
 		name: "foldCode",
 		description: "Fold code",
 		key: "Ctrl-Shift-[",
-		readOnly: false,
+		readOnly: true,
 		editorOnly: true,
 	},
 	{
 		name: "unfoldCode",
 		description: "Unfold code",
 		key: "Ctrl-Shift-]",
-		readOnly: false,
+		readOnly: true,
 		editorOnly: true,
 	},
 	{
@@ -536,14 +536,14 @@ const APP_BINDING_CONFIG = [
 		description:
 			"Fold all - top-level ranges usually depends on the syntax tree. It may not work reliably if the document isn't fully parsed (e.g., just initialized or too large to parse completely)",
 		key: "Ctrl-Alt-[",
-		readOnly: false,
+		readOnly: true,
 		editorOnly: true,
 	},
 	{
 		name: "unfoldAll",
 		description: "Unfold all folded code",
 		key: "Ctrl-Alt-]",
-		readOnly: false,
+		readOnly: true,
 		editorOnly: true,
 	},
 ];


### PR DESCRIPTION
## Changes:
Adds the following commands:

- `foldCode` - `Ctrl-Shift-[`

- `unfoldCode` - `Ctrl-shift-]`

- `foldAll` - `Ctrl-Alt-[`

- `unfoldAll` - `Ctrl-Alt-]`

----

- Adds `allowScripts` to package.json
allowed to run the following:
```
  @parcel/watcher@2.5.6 (install: node-gyp rebuild)
  core-js@3.49.0 (postinstall: node -e "try{require('./postinstall')}catch(e){}")
  core-js-pure@3.49.0 (postinstall: node -e "try{require('./postinstall')}catch(e){}")
```

Using the Old Method, as adding them to `KEYMAP_SOURCES` doesn't work due to CM not giving keys to them like other commands under `@codemirror/commands`
