### PR TITLE
refactor(core): centralize plugin unmount error boundary and fix console telemetry

### DIFF
--- a/src/lib/acode.js
+++ b/src/lib/acode.js
@@ -733,7 +733,15 @@ class Acode {
 
 	unmountPlugin(id) {
 		if (id in this.#pluginUnmount) {
-			this.#pluginUnmount[id]();
+			try {
+				this.#pluginUnmount[id]();
+			} catch (err) {
+				console.group(
+					`Error while calling unmount callback for plugin "${id}"`,
+				);
+				console.error(err);
+				console.groupEnd();
+			}
 			fsOperation(Url.join(CACHE_STORAGE, id)).delete();
 		}
 

--- a/src/lib/loadPlugin.js
+++ b/src/lib/loadPlugin.js
@@ -16,14 +16,7 @@ export default async function loadPlugin(pluginId, justInstalled = false) {
 	// listeners, etc. — is lost and can never be called. Letting the framework
 	// invoke unmountPlugin() first ensures the OLD destroy() runs while it still
 	// exists, so all old-version resources are properly cleaned up.
-	try {
-		acode.unmountPlugin(pluginId);
-	} catch (e) {
-		// unmountPlugin() itself is safe when no callback is registered (it no-ops),
-		// but a plugin's destroy() callback may throw. We catch here so a faulty
-		// cleanup in the old version does not block reloading the new one.
-		console.error(`Error while unmounting plugin "${pluginId}":`, e);
-	}
+	acode.unmountPlugin(pluginId);
 
 	// Remove the old <script> tag so the browser fetches the new source.
 	const oldScript = document.getElementById(`${pluginId}-mainScript`);


### PR DESCRIPTION
## Description
This pull request introduces an architectural refinement to Acode's plugin lifecycle management. It shifts the responsibility of exception handling during plugin teardown from the consumer orchestrator (`src/lib/loadPlugin.js`) to the core management class (`src/lib/acode.js`).

## Motivation & Architectural Justification
Previously, `loadPlugin.js` wrapped the call to `acode.unmountPlugin()` in a `try...catch` block. However, if a plugin's user-defined unmount callback threw an error, execution inside `acode.js` would immediately abort. This caused critical system cleanup routines—such as purging the plugin's cached files via `fsOperation().delete()`—to be skipped, leading to orphaned files and potential state corruption during subsequent reloads.

By centralizing the error boundary directly around the callback execution inside `acode.js`:
1. **Guaranteed Side Effects:** Filesystem cache eviction is now fully decoupled from plugin code stability and will always run.
2. **Separation of Concerns:** Higher-level loader modules no longer require defensive wrappers to handle downstream API lifecycle failures.

## Telemetry Choices & Eruda Limitations
Unlike the prevailing convention throughout the Acode codebase, this commit explicitly avoids formatting logs as `console.error("error message", new Error("cause"))`. 

### Why the Standard Pattern was Avoided:
- **Argument Serialization Flaws:** In the current embedded console layer (Eruda), passing a string message followed by an `Error` object as separate arguments causes Eruda to interpret the second argument as a generic JavaScript object. This renders it as a collapsed dropdown (`▼ Error {}`), forcing developers to manually expand properties to inspect messages and stacks, degrading triage velocity. Passing a singular, flat `Error` object ensures the stack trace unrolls automatically.

<details>
<summary>Screenshot</summary>

<img width="720" height="1600" alt="Screenshot_20260629-094354_Acode" src="https://github.com/user-attachments/assets/4fe525e4-3616-494f-acd8-c1291af7028a" />
</details>

- **Missing Chaining Support:** Eruda lacks support for modern ES2022 `{ cause }` evaluation. Passing nested exceptions results in the underlying root cause being dropped entirely from the console view.

## Known Limitations / Caveats (Not Fixed by this PR)
- **Source Map Omission:** Please note that when throwing or logging errors via `console.error(new Error("msg"))`, source maps are completely ignored by the webview/console engine. 
- **Impact:** If source files are minified, obfuscated, or bundled into single-file entry points during production compilation, stack traces will point to generated asset coordinates rather than original source lines. This PR does not attempt to patch the underlying runtime source map parsing behavior, so maintaining pristine, scannable error boundaries at runtime is prioritized.

<sub>(PR name and description are AI generated)</sub>