### PR TITLE
feat: add native app auth code login flow

### DIFF
--- a/src/components/sidebar/index.js
+++ b/src/components/sidebar/index.js
@@ -216,7 +216,7 @@ function create($container, $toggler) {
 			return;
 		}
 
-		defaultAvatar.classList.add("loading");
+		defaultAvatar.classList.add("avatar-loading");
 
 		const img = <img alt="User avatar" className="avatar" />;
 		const avatarFile = await getUserAvatar(user);

--- a/src/components/sidebar/style.scss
+++ b/src/components/sidebar/style.scss
@@ -132,6 +132,17 @@ body.no-animation {
         &.active {
           opacity: 1;
         }
+
+        &.avatar-loading {
+          opacity: 0.45;
+          background-color: rgba(255, 255, 255, 0.08);
+          animation: sidebar-avatar-loading 1.2s ease-in-out infinite;
+
+          &:hover {
+            opacity: 0.45;
+            background-color: rgba(255, 255, 255, 0.08);
+          }
+        }
       }
     }
 
@@ -337,6 +348,17 @@ body.no-animation {
       justify-content: center;
       font-weight: 600;
     }
+  }
+}
+
+@keyframes sidebar-avatar-loading {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(0.94);
   }
 }
 

--- a/src/handlers/intent.js
+++ b/src/handlers/intent.js
@@ -28,6 +28,10 @@ export default async function HandleIntent(intent = {}) {
 			const path = url.replace("acode://", "");
 			const [module, action, value] = path.split("/");
 
+			if (module === "auth" && action === "callback") {
+				return;
+			}
+
 			let defaultPrevented = false;
 			const event = new IntentEvent(module, action, value);
 			for (const handler of handlers) {

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -1,7 +1,4 @@
-import toast from "components/toast";
-import { addIntentHandler } from "handlers/intent";
 import config from "./config";
-import customTab from "./customTab";
 
 /**
  * @typedef {object} User
@@ -50,7 +47,6 @@ class AuthService {
 	#loginTimeout = null;
 
 	constructor() {
-		addIntentHandler(this.onIntentReceiver.bind(this));
 		loginEvents.addListener(() => {
 			clearTimeout(this.#loginTimeout);
 			for (const callback of this.#loginCallbacks) {
@@ -68,25 +64,6 @@ class AuthService {
 				this.#loginCallbacks.clear();
 			}, 1000);
 		});
-	}
-
-	async onIntentReceiver(event) {
-		try {
-			if (event?.module === "user" && event?.action === "login") {
-				if (event?.value) {
-					this.#exec("saveToken", [event.value]);
-					toast("Logged in successfully");
-
-					setTimeout(() => {
-						loginEvents.emit();
-					}, 500);
-				}
-			}
-			return null;
-		} catch (error) {
-			console.error("Failed to parse intent token.", error);
-			return null;
-		}
 	}
 
 	/**
@@ -159,12 +136,22 @@ class AuthService {
 
 	async login() {
 		return new Promise((resolve, reject) => {
-			customTab(`${config.BASE_URL}/login?redirect=app`).catch((err) => {
-				console.error("Custom tab error", err);
-				reject("Failed to open browser");
-			});
-
-			this.#loginCallbacks.add({ resolve, reject });
+			const callback = { resolve, reject };
+			this.#loginCallbacks.add(callback);
+			this.#exec("login", [
+				{
+					baseUrl: config.BASE_URL,
+					appVersionCode: window.BuildInfo?.versionCode || 0,
+				},
+			])
+				.then(() => {
+					loginEvents.emit();
+				})
+				.catch((err) => {
+					console.error("Native login error", err);
+					this.#loginCallbacks.delete(callback);
+					reject("Failed to login");
+				});
 		});
 	}
 }

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -26,6 +26,7 @@ let loggedInUser = null;
 let cacheTimeout = null;
 
 const CACHE_USER_KEY = "cached-logged-in-user";
+const LOGIN_RESUME_TIMEOUT_MS = 60_000;
 
 const loginEvents = {
 	listeners: new Set(),
@@ -62,7 +63,7 @@ class AuthService {
 				}
 
 				this.#loginCallbacks.clear();
-			}, 1000);
+			}, LOGIN_RESUME_TIMEOUT_MS);
 		});
 	}
 

--- a/src/lib/checkPluginsUpdate.js
+++ b/src/lib/checkPluginsUpdate.js
@@ -37,7 +37,10 @@ export default async function checkPluginsUpdate() {
 						.readFile("json")
 						.catch(() => null);
 
-					if (isVersionGreater(remotePlugin?.version, plugin.version)) {
+					if (
+						!remotePlugin?.version ||
+						isVersionGreater(remotePlugin.version, plugin.version)
+					) {
 						updates.push(plugin.id);
 					}
 				}

--- a/src/lib/checkPluginsUpdate.js
+++ b/src/lib/checkPluginsUpdate.js
@@ -1,5 +1,6 @@
 import fsOperation from "fileSystem";
 import Url from "utils/Url";
+import { isVersionGreater } from "utils/version";
 import config from "./config";
 
 export default async function checkPluginsUpdate() {
@@ -20,7 +21,23 @@ export default async function checkPluginsUpdate() {
 
 				if (res.ok) {
 					const json = await res.json();
-					if (json.update) {
+					if (!json.update) return;
+
+					if (json.version) {
+						if (isVersionGreater(json.version, plugin.version)) {
+							updates.push(plugin.id);
+						}
+						return;
+					}
+
+					const remotePlugin = await fsOperation(
+						config.API_BASE,
+						`plugin/${plugin.id}`,
+					)
+						.readFile("json")
+						.catch(() => null);
+
+					if (isVersionGreater(remotePlugin?.version, plugin.version)) {
 						updates.push(plugin.id);
 					}
 				}

--- a/src/lib/installPlugin.js
+++ b/src/lib/installPlugin.js
@@ -6,6 +6,7 @@ import purchaseListener from "handlers/purchase";
 import JSZip from "jszip";
 import helpers from "utils/helpers";
 import Url from "utils/Url";
+import { isVersionGreater } from "utils/version";
 import config from "./config";
 import InstallState from "./installState";
 import { loadPluginWithTimeout } from "./loadPlugins";
@@ -406,7 +407,8 @@ async function resolveDepsManifest(deps) {
 			throw new Error(`Unknown plugin dependency: ${dependency}`);
 
 		const version = await getInstalledPluginVersion(remoteDependency.id);
-		if (remoteDependency?.version === version) continue;
+		if (version && !isVersionGreater(remoteDependency?.version, version))
+			continue;
 
 		if (remoteDependency.dependencies) {
 			const manifests = await resolveDepsManifest(

--- a/src/pages/plugin/plugin.js
+++ b/src/pages/plugin/plugin.js
@@ -21,6 +21,7 @@ import markdownItTaskLists from "markdown-it-task-lists";
 import { highlightCodeBlock, initHighlighting } from "utils/codeHighlight";
 import helpers from "utils/helpers";
 import Url from "utils/Url";
+import { isVersionGreater } from "utils/version";
 import view, { cleanups } from "./plugin.view.js";
 
 let $lastPluginPage;
@@ -160,7 +161,10 @@ export default async function PluginInclude(
 
 					if (cancelled || !remotePlugin) return;
 
-					if (installed && remotePlugin?.version !== plugin.version) {
+					if (
+						installed &&
+						isVersionGreater(remotePlugin?.version, plugin.version)
+					) {
 						currentVersion = plugin.version;
 						update = true;
 					}

--- a/src/plugins/auth/plugin.xml
+++ b/src/plugins/auth/plugin.xml
@@ -12,6 +12,7 @@
         </config-file>
 
         <framework src="androidx.security:security-crypto:1.1.0" />
+        <framework src="androidx.browser:browser:1.5.0" />
 
         <source-file src="src/android/Authenticator.java" target-dir="src/com/foxdebug/acode/rk/auth" />
         <source-file src="src/android/EncryptedPreferenceManager.java" target-dir="src/com/foxdebug/acode/rk/auth" />

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -30,6 +30,8 @@ public class Authenticator extends CordovaPlugin {
     private static final String KEY_PENDING_STATE = "pending_login_state";
     private static final String KEY_PENDING_VERIFIER = "pending_login_verifier";
     private static final String KEY_PENDING_BASE_URL = "pending_login_base_url";
+    private static final int AUTH_CONNECT_TIMEOUT_MS = 15_000;
+    private static final int AUTH_READ_TIMEOUT_MS = 30_000;
     private static final String[] API_ORIGINS = {
         "https://acode.app"
     };
@@ -38,7 +40,8 @@ public class Authenticator extends CordovaPlugin {
         "https://dev.acode.app"
     };
     private EncryptedPreferenceManager prefManager;
-    private CallbackContext loginCallback;
+    private final Object loginCallbackLock = new Object();
+    private volatile CallbackContext loginCallback;
 
     @Override
     protected void pluginInitialize() {
@@ -106,7 +109,7 @@ public class Authenticator extends CordovaPlugin {
         prefManager.setString(KEY_PENDING_STATE, state);
         prefManager.setString(KEY_PENDING_VERIFIER, verifier);
         prefManager.setString(KEY_PENDING_BASE_URL, baseUrl);
-        loginCallback = callbackContext;
+        setLoginCallback(callbackContext);
 
         Uri loginUri = Uri.parse(baseUrl)
             .buildUpon()
@@ -135,7 +138,7 @@ public class Authenticator extends CordovaPlugin {
                     result.setKeepCallback(true);
                     callbackContext.sendPluginResult(result);
                 } catch (Exception fallbackError) {
-                    callbackContext.error(fallbackError.getMessage());
+                    failLogin(fallbackError.getMessage());
                 }
             }
         });
@@ -166,9 +169,9 @@ public class Authenticator extends CordovaPlugin {
                 prefManager.remove(KEY_PENDING_VERIFIER);
                 prefManager.remove(KEY_PENDING_BASE_URL);
                 cordova.getActivity().runOnUiThread(() -> setTokenCookie(token));
-                if (loginCallback != null) {
-                    loginCallback.success();
-                    loginCallback = null;
+                CallbackContext callback = takeLoginCallback();
+                if (callback != null) {
+                    callback.success();
                 }
             } catch (Exception error) {
                 Log.e(TAG, "Failed to exchange app auth code", error);
@@ -182,34 +185,40 @@ public class Authenticator extends CordovaPlugin {
     private String exchangeCode(String baseUrl, String code, String state, String verifier) throws Exception {
         URL url = new URL(baseUrl + "/api/user/app-token/exchange");
         HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-        connection.setRequestMethod("POST");
-        connection.setRequestProperty("Content-Type", "application/json");
-        connection.setDoOutput(true);
+        try {
+            connection.setConnectTimeout(AUTH_CONNECT_TIMEOUT_MS);
+            connection.setReadTimeout(AUTH_READ_TIMEOUT_MS);
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setDoOutput(true);
 
-        JSONObject body = new JSONObject();
-        body.put("code", code);
-        body.put("state", state);
-        body.put("verifier", verifier);
+            JSONObject body = new JSONObject();
+            body.put("code", code);
+            body.put("state", state);
+            body.put("verifier", verifier);
 
-        try (OutputStream os = connection.getOutputStream()) {
-            os.write(body.toString().getBytes(StandardCharsets.UTF_8));
+            try (OutputStream os = connection.getOutputStream()) {
+                os.write(body.toString().getBytes(StandardCharsets.UTF_8));
+            }
+
+            int status = connection.getResponseCode();
+            InputStream stream = status >= 200 && status < 300 ? connection.getInputStream() : connection.getErrorStream();
+            String response = readStream(stream);
+
+            if (status < 200 || status >= 300) {
+                throw new IllegalStateException(response);
+            }
+
+            JSONObject json = new JSONObject(response);
+            String token = json.optString("token", "");
+            if (token.isEmpty()) {
+                throw new IllegalStateException("Missing token");
+            }
+
+            return token;
+        } finally {
+            connection.disconnect();
         }
-
-        int status = connection.getResponseCode();
-        InputStream stream = status >= 200 && status < 300 ? connection.getInputStream() : connection.getErrorStream();
-        String response = readStream(stream);
-
-        if (status < 200 || status >= 300) {
-            throw new IllegalStateException(response);
-        }
-
-        JSONObject json = new JSONObject(response);
-        String token = json.optString("token", "");
-        if (token.isEmpty()) {
-            throw new IllegalStateException("Missing token");
-        }
-
-        return token;
     }
 
     private String readStream(InputStream stream) throws Exception {
@@ -228,9 +237,23 @@ public class Authenticator extends CordovaPlugin {
         prefManager.remove(KEY_PENDING_STATE);
         prefManager.remove(KEY_PENDING_VERIFIER);
         prefManager.remove(KEY_PENDING_BASE_URL);
-        if (loginCallback != null) {
-            loginCallback.error(message);
+        CallbackContext callback = takeLoginCallback();
+        if (callback != null) {
+            callback.error(message);
+        }
+    }
+
+    private void setLoginCallback(CallbackContext callbackContext) {
+        synchronized (loginCallbackLock) {
+            loginCallback = callbackContext;
+        }
+    }
+
+    private CallbackContext takeLoginCallback() {
+        synchronized (loginCallbackLock) {
+            CallbackContext callback = loginCallback;
             loginCallback = null;
+            return callback;
         }
     }
 

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -244,8 +244,13 @@ public class Authenticator extends CordovaPlugin {
     }
 
     private void setLoginCallback(CallbackContext callbackContext) {
+        CallbackContext previousCallback = null;
         synchronized (loginCallbackLock) {
+            previousCallback = loginCallback;
             loginCallback = callbackContext;
+        }
+        if (previousCallback != null) {
+            previousCallback.error("Login cancelled");
         }
     }
 

--- a/src/plugins/auth/src/android/Authenticator.java
+++ b/src/plugins/auth/src/android/Authenticator.java
@@ -1,12 +1,25 @@
 package com.foxdebug.acode.rk.auth;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.util.Log;
 import android.webkit.CookieManager;
 import android.webkit.WebView;
+import androidx.browser.customtabs.CustomTabsIntent;
 import com.foxdebug.acode.rk.auth.EncryptedPreferenceManager;
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
 import org.apache.cordova.*;
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 public class Authenticator extends CordovaPlugin {
     private static final String TAG = "AcodeAuth";
@@ -14,6 +27,9 @@ public class Authenticator extends CordovaPlugin {
     private static final String KEY_TOKEN = "auth_token";
     private static final String PRO_PURCHASED = "pro_purchased";
     private static final String KEY_MIGRATED_V2 = "migrated_host_to_domain_cookies";
+    private static final String KEY_PENDING_STATE = "pending_login_state";
+    private static final String KEY_PENDING_VERIFIER = "pending_login_verifier";
+    private static final String KEY_PENDING_BASE_URL = "pending_login_base_url";
     private static final String[] API_ORIGINS = {
         "https://acode.app"
     };
@@ -22,6 +38,7 @@ public class Authenticator extends CordovaPlugin {
         "https://dev.acode.app"
     };
     private EncryptedPreferenceManager prefManager;
+    private CallbackContext loginCallback;
 
     @Override
     protected void pluginInitialize() {
@@ -41,6 +58,8 @@ public class Authenticator extends CordovaPlugin {
         if (!token.isEmpty()) {
             setTokenCookie(token);
         }
+
+        handleAuthCallback(cordova.getActivity().getIntent());
     }
 
     @Override
@@ -60,9 +79,181 @@ public class Authenticator extends CordovaPlugin {
                 cordova.getActivity().runOnUiThread(() -> setTokenCookie(token));
                 callbackContext.success();
                 return true;
+            case "login":
+                JSONObject options = args.optJSONObject(0);
+                startLogin(options != null ? options : new JSONObject(), callbackContext);
+                return true;
             default:
                 Log.w(TAG, "Attempted to call unknown action: " + action);
                 return false;
+        }
+    }
+
+    @Override
+    public void onNewIntent(Intent intent) {
+        if (!handleAuthCallback(intent)) {
+            super.onNewIntent(intent);
+        }
+    }
+
+    private void startLogin(JSONObject options, CallbackContext callbackContext) {
+        String baseUrl = options.optString("baseUrl", "https://acode.app");
+        int appVersionCode = options.optInt("appVersionCode", 0);
+        String state = randomHex(24);
+        String verifier = randomHex(32);
+        String challenge = sha256Hex(verifier);
+
+        prefManager.setString(KEY_PENDING_STATE, state);
+        prefManager.setString(KEY_PENDING_VERIFIER, verifier);
+        prefManager.setString(KEY_PENDING_BASE_URL, baseUrl);
+        loginCallback = callbackContext;
+
+        Uri loginUri = Uri.parse(baseUrl)
+            .buildUpon()
+            .appendEncodedPath("login")
+            .appendQueryParameter("redirect", "app")
+            .appendQueryParameter("authFlow", "app-code")
+            .appendQueryParameter("state", state)
+            .appendQueryParameter("challenge", challenge)
+            .appendQueryParameter("appVersionCode", String.valueOf(appVersionCode))
+            .build();
+
+        cordova.getActivity().runOnUiThread(() -> {
+            try {
+                CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
+                customTabsIntent.intent.putExtra(CustomTabsIntent.EXTRA_TITLE_VISIBILITY_STATE, CustomTabsIntent.SHOW_PAGE_TITLE);
+                customTabsIntent.launchUrl(cordova.getActivity(), loginUri);
+
+                PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+                result.setKeepCallback(true);
+                callbackContext.sendPluginResult(result);
+            } catch (Exception error) {
+                Intent fallback = new Intent(Intent.ACTION_VIEW, loginUri);
+                try {
+                    cordova.getActivity().startActivity(fallback);
+                    PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
+                    result.setKeepCallback(true);
+                    callbackContext.sendPluginResult(result);
+                } catch (Exception fallbackError) {
+                    callbackContext.error(fallbackError.getMessage());
+                }
+            }
+        });
+    }
+
+    private boolean handleAuthCallback(Intent intent) {
+        Uri data = intent != null ? intent.getData() : null;
+        if (data == null || !"acode".equals(data.getScheme()) || !"auth".equals(data.getHost()) || !"/callback".equals(data.getPath())) {
+            return false;
+        }
+
+        String code = data.getQueryParameter("code");
+        String state = data.getQueryParameter("state");
+        String expectedState = prefManager.getString(KEY_PENDING_STATE, "");
+        String verifier = prefManager.getString(KEY_PENDING_VERIFIER, "");
+        String baseUrl = prefManager.getString(KEY_PENDING_BASE_URL, "https://acode.app");
+
+        if (code == null || state == null || expectedState.isEmpty() || verifier.isEmpty() || !expectedState.equals(state)) {
+            failLogin("Invalid login callback");
+            return true;
+        }
+
+        cordova.getThreadPool().execute(() -> {
+            try {
+                String token = exchangeCode(baseUrl, code, state, verifier);
+                prefManager.setString(KEY_TOKEN, token);
+                prefManager.remove(KEY_PENDING_STATE);
+                prefManager.remove(KEY_PENDING_VERIFIER);
+                prefManager.remove(KEY_PENDING_BASE_URL);
+                cordova.getActivity().runOnUiThread(() -> setTokenCookie(token));
+                if (loginCallback != null) {
+                    loginCallback.success();
+                    loginCallback = null;
+                }
+            } catch (Exception error) {
+                Log.e(TAG, "Failed to exchange app auth code", error);
+                failLogin("Unable to complete login");
+            }
+        });
+
+        return true;
+    }
+
+    private String exchangeCode(String baseUrl, String code, String state, String verifier) throws Exception {
+        URL url = new URL(baseUrl + "/api/user/app-token/exchange");
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("Content-Type", "application/json");
+        connection.setDoOutput(true);
+
+        JSONObject body = new JSONObject();
+        body.put("code", code);
+        body.put("state", state);
+        body.put("verifier", verifier);
+
+        try (OutputStream os = connection.getOutputStream()) {
+            os.write(body.toString().getBytes(StandardCharsets.UTF_8));
+        }
+
+        int status = connection.getResponseCode();
+        InputStream stream = status >= 200 && status < 300 ? connection.getInputStream() : connection.getErrorStream();
+        String response = readStream(stream);
+
+        if (status < 200 || status >= 300) {
+            throw new IllegalStateException(response);
+        }
+
+        JSONObject json = new JSONObject(response);
+        String token = json.optString("token", "");
+        if (token.isEmpty()) {
+            throw new IllegalStateException("Missing token");
+        }
+
+        return token;
+    }
+
+    private String readStream(InputStream stream) throws Exception {
+        if (stream == null) return "";
+        StringBuilder builder = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                builder.append(line);
+            }
+        }
+        return builder.toString();
+    }
+
+    private void failLogin(String message) {
+        prefManager.remove(KEY_PENDING_STATE);
+        prefManager.remove(KEY_PENDING_VERIFIER);
+        prefManager.remove(KEY_PENDING_BASE_URL);
+        if (loginCallback != null) {
+            loginCallback.error(message);
+            loginCallback = null;
+        }
+    }
+
+    private String randomHex(int byteCount) {
+        byte[] bytes = new byte[byteCount];
+        new SecureRandom().nextBytes(bytes);
+        StringBuilder builder = new StringBuilder(byteCount * 2);
+        for (byte b : bytes) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+
+    private String sha256Hex(String value) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder(hash.length * 2);
+            for (byte b : hash) {
+                builder.append(String.format("%02x", b));
+            }
+            return builder.toString();
+        } catch (Exception error) {
+            throw new IllegalStateException("Unable to create auth challenge", error);
         }
     }
 

--- a/src/plugins/system/android/com/foxdebug/system/System.java
+++ b/src/plugins/system/android/com/foxdebug/system/System.java
@@ -1885,6 +1885,12 @@ public class System extends CordovaPlugin {
 
     private void getCordovaIntent(CallbackContext callback) {
         Intent intent = activity.getIntent();
+        if (isReservedAuthIntent(intent)) {
+            callback.sendPluginResult(
+                new PluginResult(PluginResult.Status.OK, new JSONObject())
+            );
+            return;
+        }
         callback.sendPluginResult(
             new PluginResult(PluginResult.Status.OK, getIntentJson(intent))
         );
@@ -1899,6 +1905,9 @@ public class System extends CordovaPlugin {
 
     @Override
     public void onNewIntent(Intent intent) {
+        if (isReservedAuthIntent(intent)) {
+            return;
+        }
         if (intentHandler != null) {
             PluginResult result = new PluginResult(
                 PluginResult.Status.OK,
@@ -1907,6 +1916,16 @@ public class System extends CordovaPlugin {
             result.setKeepCallback(true);
             intentHandler.sendPluginResult(result);
         }
+    }
+
+    private boolean isReservedAuthIntent(Intent intent) {
+        Uri data = intent != null ? intent.getData() : null;
+        if (data == null || !"acode".equals(data.getScheme())) {
+            return false;
+        }
+        String host = data.getHost();
+        String path = data.getPath();
+        return "auth".equals(host) && "/callback".equals(path);
     }
 
     private JSONObject getIntentJson(Intent intent) {

--- a/src/test/sanity.tests.js
+++ b/src/test/sanity.tests.js
@@ -1,8 +1,3 @@
-import {
-	clearModifierState,
-	clearQuickToolsButtonFeedback,
-	removeActionStackEntries,
-} from "../handlers/quickToolsState";
 import { getLanguageModeRecommendationSearchKeyword } from "../lib/languageModeRecommendations";
 import { isVersionGreater } from "../utils/version";
 import { TestRunner } from "./tester";
@@ -107,71 +102,6 @@ export async function runSanityTests(writeOutput) {
 				!isVersionGreater("1.0.0", "1.1.1"),
 				"Lower remote versions should not be updates",
 			);
-		},
-	);
-
-	runner.test("Quick tools modifier cleanup emits inactive state", (test) => {
-		const state = {
-			shift: true,
-			alt: true,
-			ctrl: true,
-			meta: true,
-		};
-		const emitted = [];
-		const events = {
-			shift: [(value) => emitted.push(["shift", value])],
-			alt: [(value) => emitted.push(["alt", value])],
-			ctrl: [(value) => emitted.push(["ctrl", value])],
-			meta: [(value) => emitted.push(["meta", value])],
-		};
-
-		test.assert(clearModifierState(state, events));
-		test.assertEqual(state.shift, false);
-		test.assertEqual(state.alt, false);
-		test.assertEqual(state.ctrl, false);
-		test.assertEqual(state.meta, false);
-		test.assertEqual(
-			JSON.stringify(emitted),
-			JSON.stringify([
-				["shift", false],
-				["alt", false],
-				["ctrl", false],
-				["meta", false],
-			]),
-		);
-	});
-
-	runner.test(
-		"Quick tools feedback cleanup clears stale button state",
-		(test) => {
-			const container = document.createElement("div");
-			const button = document.createElement("button");
-			button.className = "icon active click";
-			button.dataset.timeout = setTimeout(() => {}, 1000);
-			container.append(button);
-
-			test.assertEqual(clearQuickToolsButtonFeedback([container]), 1);
-			test.assert(!button.classList.contains("active"));
-			test.assert(!button.classList.contains("click"));
-			test.assertEqual(button.dataset.timeout, undefined);
-		},
-	);
-
-	runner.test(
-		"Quick tools search cleanup removes duplicate stack entries",
-		(test) => {
-			const entries = ["search-bar", "other", "search-bar"];
-			const stack = {
-				remove(id) {
-					const index = entries.indexOf(id);
-					if (index === -1) return false;
-					entries.splice(index, 1);
-					return true;
-				},
-			};
-
-			test.assertEqual(removeActionStackEntries(stack, "search-bar"), 2);
-			test.assertEqual(JSON.stringify(entries), JSON.stringify(["other"]));
 		},
 	);
 

--- a/src/test/sanity.tests.js
+++ b/src/test/sanity.tests.js
@@ -1,4 +1,10 @@
+import {
+	clearModifierState,
+	clearQuickToolsButtonFeedback,
+	removeActionStackEntries,
+} from "../handlers/quickToolsState";
 import { getLanguageModeRecommendationSearchKeyword } from "../lib/languageModeRecommendations";
+import { isVersionGreater } from "../utils/version";
 import { TestRunner } from "./tester";
 
 export async function runSanityTests(writeOutput) {
@@ -81,6 +87,93 @@ export async function runSanityTests(writeOutput) {
 			"Extensionless non-dotfiles should not request plugin recommendations",
 		);
 	});
+
+	runner.test(
+		"Plugin version comparison only accepts newer versions",
+		(test) => {
+			test.assert(
+				isVersionGreater("1.1.2", "1.1.1"),
+				"Patch updates should be newer",
+			);
+			test.assert(
+				isVersionGreater("1.2.0", "1.1.9"),
+				"Minor updates should be newer",
+			);
+			test.assert(
+				!isVersionGreater("1.1.1", "1.1.1"),
+				"Equal versions should not be updates",
+			);
+			test.assert(
+				!isVersionGreater("1.0.0", "1.1.1"),
+				"Lower remote versions should not be updates",
+			);
+		},
+	);
+
+	runner.test("Quick tools modifier cleanup emits inactive state", (test) => {
+		const state = {
+			shift: true,
+			alt: true,
+			ctrl: true,
+			meta: true,
+		};
+		const emitted = [];
+		const events = {
+			shift: [(value) => emitted.push(["shift", value])],
+			alt: [(value) => emitted.push(["alt", value])],
+			ctrl: [(value) => emitted.push(["ctrl", value])],
+			meta: [(value) => emitted.push(["meta", value])],
+		};
+
+		test.assert(clearModifierState(state, events));
+		test.assertEqual(state.shift, false);
+		test.assertEqual(state.alt, false);
+		test.assertEqual(state.ctrl, false);
+		test.assertEqual(state.meta, false);
+		test.assertEqual(
+			JSON.stringify(emitted),
+			JSON.stringify([
+				["shift", false],
+				["alt", false],
+				["ctrl", false],
+				["meta", false],
+			]),
+		);
+	});
+
+	runner.test(
+		"Quick tools feedback cleanup clears stale button state",
+		(test) => {
+			const container = document.createElement("div");
+			const button = document.createElement("button");
+			button.className = "icon active click";
+			button.dataset.timeout = setTimeout(() => {}, 1000);
+			container.append(button);
+
+			test.assertEqual(clearQuickToolsButtonFeedback([container]), 1);
+			test.assert(!button.classList.contains("active"));
+			test.assert(!button.classList.contains("click"));
+			test.assertEqual(button.dataset.timeout, undefined);
+		},
+	);
+
+	runner.test(
+		"Quick tools search cleanup removes duplicate stack entries",
+		(test) => {
+			const entries = ["search-bar", "other", "search-bar"];
+			const stack = {
+				remove(id) {
+					const index = entries.indexOf(id);
+					if (index === -1) return false;
+					entries.splice(index, 1);
+					return true;
+				},
+			};
+
+			test.assertEqual(removeActionStackEntries(stack, "search-bar"), 2);
+			test.assertEqual(JSON.stringify(entries), JSON.stringify(["other"]));
+		},
+	);
 
 	// Run all tests
 	return await runner.run(writeOutput);

--- a/src/utils/version.js
+++ b/src/utils/version.js
@@ -1,0 +1,35 @@
+export function parseVersion(version) {
+	const parts = String(version || "")
+		.trim()
+		.replace(/^v/i, "")
+		.split(".");
+
+	if (parts.length !== 3) return null;
+
+	const numbers = parts.map((part) => {
+		if (!/^\d+$/.test(part)) return Number.NaN;
+		return Number(part);
+	});
+
+	if (numbers.some((part) => !Number.isSafeInteger(part))) return null;
+
+	return numbers;
+}
+
+export function compareVersions(versionA, versionB) {
+	const a = parseVersion(versionA);
+	const b = parseVersion(versionB);
+
+	if (!a || !b) return 0;
+
+	for (let i = 0; i < a.length; i++) {
+		if (a[i] > b[i]) return 1;
+		if (a[i] < b[i]) return -1;
+	}
+
+	return 0;
+}
+
+export function isVersionGreater(newVersion, currentVersion) {
+	return compareVersions(newVersion, currentVersion) > 0;
+}


### PR DESCRIPTION
- move Android login to custom tab auth-code exchange
- handle reserved auth callback intents natively
- add semantic plugin version comparison for updates
- improve sidebar avatar loading state
- cover auth/version and quick-tools behavior in sanity tests