### PR TITLE
fix: implement editor tab history navigation (#1819)

### DIFF
--- a/src/cm/commandRegistry.js
+++ b/src/cm/commandRegistry.js
@@ -364,6 +364,26 @@ function registerCoreCommands() {
 		},
 	});
 	addCommand({
+		name: "nextFileHistory",
+		description: "Open next file tab from history",
+		readOnly: true,
+		requiresView: false,
+		run() {
+			acode.exec("next-file-history");
+			return true;
+		},
+	});
+	addCommand({
+		name: "prevFileHistory",
+		description: "Open previous file tab from history",
+		readOnly: true,
+		requiresView: false,
+		run() {
+			acode.exec("prev-file-history");
+			return true;
+		},
+	});
+	addCommand({
 		name: "showSettingsMenu",
 		description: "Show settings menu",
 		readOnly: true,
@@ -1637,7 +1657,19 @@ async function loadCustomKeyBindings() {
 		if (await bindingsFile.exists()) {
 			const bindings = await bindingsFile.readFile("json");
 			if (bindings && typeof bindings === "object") {
+				let updated = false;
+				Object.keys(keyBindings).forEach((key) => {
+					if (!(key in bindings)) {
+						bindings[key] = keyBindings[key];
+						updated = true;
+					}
+				});
 				resolvedKeyBindings = bindings;
+				if (updated) {
+					bindingsFile
+						.writeFile(JSON.stringify(bindings, undefined, 2))
+						.catch(() => {});
+				}
 			}
 		} else {
 			throw new Error("Key binding file not found");

--- a/src/cm/commandRegistry.js
+++ b/src/cm/commandRegistry.js
@@ -1668,7 +1668,10 @@ async function loadCustomKeyBindings() {
 				if (updated) {
 					bindingsFile
 						.writeFile(JSON.stringify(bindings, undefined, 2))
-						.catch(() => {});
+						.catch((error) => {
+							window.log?.("error", "Failed to back-fill new key bindings!");
+							window.log?.("error", error);
+						});
 				}
 			}
 		} else {

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -300,6 +300,12 @@ export default {
 
 		files[fileIndex].makeActive();
 	},
+	"next-file-history"() {
+		editorManager.openNextEditorFromHistory?.();
+	},
+	openNextEditorFromHistory() {
+		editorManager.openNextEditorFromHistory?.();
+	},
 	async open(page) {
 		switch (page) {
 			case "settings":
@@ -377,6 +383,12 @@ export default {
 		else --fileIndex;
 
 		files[fileIndex].makeActive();
+	},
+	"prev-file-history"() {
+		editorManager.openPreviousEditorFromHistory?.();
+	},
+	openPreviousEditorFromHistory() {
+		editorManager.openPreviousEditorFromHistory?.();
 	},
 	"read-only"() {
 		const file = editorManager.activeFile;

--- a/src/lib/commands.js
+++ b/src/lib/commands.js
@@ -303,9 +303,6 @@ export default {
 	"next-file-history"() {
 		editorManager.openNextEditorFromHistory?.();
 	},
-	openNextEditorFromHistory() {
-		editorManager.openNextEditorFromHistory?.();
-	},
 	async open(page) {
 		switch (page) {
 			case "settings":
@@ -385,9 +382,6 @@ export default {
 		files[fileIndex].makeActive();
 	},
 	"prev-file-history"() {
-		editorManager.openPreviousEditorFromHistory?.();
-	},
-	openPreviousEditorFromHistory() {
 		editorManager.openPreviousEditorFromHistory?.();
 	},
 	"read-only"() {

--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -138,6 +138,9 @@ async function EditorManager($header, $body) {
 	let touchSelectionSyncRaf = 0;
 	let nativeContextMenuDisabled = null;
 	const recoverableWarningKeys = new Set();
+	let historyStack = [];
+	let historyIndex = -1;
+	let isNavigatingHistory = false;
 
 	function warnRecoverable(message, error, key) {
 		if (key) {
@@ -705,6 +708,7 @@ async function EditorManager($header, $body) {
 			updateActivePaneScrollbars();
 			toggleProblemButton();
 			if (options.emitSwitch !== false && manager.activeFile) {
+				recordHistory(manager.activeFile);
 				manager.onupdate("switch-file");
 				events.emit("switch-file", manager.activeFile);
 			}
@@ -3152,6 +3156,15 @@ async function EditorManager($header, $body) {
 		getEditorHeight,
 		getEditorWidth,
 		header: $header,
+		openPreviousEditorFromHistory,
+		openNextEditorFromHistory,
+		recordHistory,
+		get editorHistory() {
+			return historyStack;
+		},
+		get editorHistoryIndex() {
+			return historyIndex;
+		},
 		getLspMetadata: buildLspMetadata,
 		get editor() {
 			return getActivePane()?.editor || editor;
@@ -3647,6 +3660,7 @@ async function EditorManager($header, $body) {
 	});
 
 	manager.on(["remove-file"], (file) => {
+		removeFileFromHistory(file);
 		clearDocSyncTimers(file);
 		detachLspForFile(file);
 		toggleProblemButton();
@@ -4204,7 +4218,7 @@ async function EditorManager($header, $body) {
 		setNativeContextMenuDisabled(isFocused);
 
 		function handleContentFocus(_event) {
-			setActivePane(pane);
+			setActivePane(pane, { emitSwitch: false });
 			setNativeContextMenuDisabled(true);
 			const activeFile = pane.activeFile;
 			if (activeFile) {
@@ -4746,6 +4760,7 @@ async function EditorManager($header, $body) {
 				file.tab?.classList.add("active");
 				updateHeaderForFile(file);
 				if (isPaneTabLayout()) syncGlobalOpenFileListMirror();
+				recordHistory(file);
 				manager.onupdate("switch-file");
 				events.emit("switch-file", file);
 				toggleProblemButton();
@@ -4812,6 +4827,7 @@ async function EditorManager($header, $body) {
 				}
 			}
 		}
+		recordHistory(file);
 		manager.onupdate("switch-file");
 		events.emit("switch-file", file);
 
@@ -4822,6 +4838,74 @@ async function EditorManager($header, $body) {
 		const file = manager.activeFile;
 		if (!file || file.type !== "editor" || !file.loaded || file.loading) return;
 		applyFileToEditor(file, { forceRecreate: true });
+	}
+
+	function recordHistory(file) {
+		if (!file || isNavigatingHistory) return;
+		const current = historyStack[historyIndex];
+		if (current?.id === file.id) return;
+
+		historyStack = historyStack.slice(0, historyIndex + 1);
+		historyStack.push(file);
+		historyIndex = historyStack.length - 1;
+
+		const MAX_HISTORY = 100;
+		if (historyStack.length > MAX_HISTORY) {
+			historyStack.shift();
+			historyIndex = Math.max(0, historyIndex - 1);
+		}
+	}
+
+	function removeFileFromHistory(file) {
+		if (!file) return;
+		for (let i = historyStack.length - 1; i >= 0; i--) {
+			if (historyStack[i]?.id === file.id) {
+				historyStack.splice(i, 1);
+				if (i <= historyIndex) {
+					historyIndex--;
+				}
+			}
+		}
+		if (historyIndex < 0 && historyStack.length > 0) {
+			historyIndex = 0;
+		}
+	}
+
+	function openPreviousEditorFromHistory() {
+		while (historyIndex > 0) {
+			historyIndex--;
+			const file = historyStack[historyIndex];
+			if (file && getFile(file.id, "id")) {
+				isNavigatingHistory = true;
+				try {
+					file.makeActive();
+				} finally {
+					isNavigatingHistory = false;
+				}
+				return true;
+			}
+			historyStack.splice(historyIndex, 1);
+		}
+		return false;
+	}
+
+	function openNextEditorFromHistory() {
+		while (historyIndex < historyStack.length - 1) {
+			historyIndex++;
+			const file = historyStack[historyIndex];
+			if (file && getFile(file.id, "id")) {
+				isNavigatingHistory = true;
+				try {
+					file.makeActive();
+				} finally {
+					isNavigatingHistory = false;
+				}
+				return true;
+			}
+			historyStack.splice(historyIndex, 1);
+			historyIndex--;
+		}
+		return false;
 	}
 
 	/**

--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -4218,7 +4218,7 @@ async function EditorManager($header, $body) {
 		setNativeContextMenuDisabled(isFocused);
 
 		function handleContentFocus(_event) {
-			setActivePane(pane, { emitSwitch: false });
+			setActivePane(pane);
 			setNativeContextMenuDisabled(true);
 			const activeFile = pane.activeFile;
 			if (activeFile) {

--- a/src/lib/keyBindings.js
+++ b/src/lib/keyBindings.js
@@ -123,6 +123,20 @@ const APP_BINDING_CONFIG = [
 		readOnly: true,
 	},
 	{
+		name: "nextFileHistory",
+		description: "Open next file tab from history",
+		key: null,
+		action: "next-file-history",
+		readOnly: true,
+	},
+	{
+		name: "prevFileHistory",
+		description: "Open previous file tab from history",
+		key: null,
+		action: "prev-file-history",
+		readOnly: true,
+	},
+	{
 		name: "splitPaneRight",
 		description: "Split editor pane right",
 		key: "Ctrl-\\",


### PR DESCRIPTION
Implements editor tab visit history tracking and navigation commands (`prevFileHistory` / `nextFileHistory`), allowing users to traverse their open tabs in chronological order of visit rather than strictly left-to-right visual tab order.

Closes #1819