### PR TITLE
feat(files): move workspace indexing and search to native for saf/files

### DIFF
--- a/src/components/fileTree/index.js
+++ b/src/components/fileTree/index.js
@@ -373,6 +373,8 @@ export default class FileTree {
 	 * @param {boolean} isDirectory
 	 */
 	appendEntry(name, url, isDirectory) {
+		if (this.entries.some((entry) => entry.url === url)) return;
+
 		const entry = { name, url, isDirectory, isFile: !isDirectory };
 
 		// Insert in sorted position
@@ -399,10 +401,10 @@ export default class FileTree {
 			// Virtual list mode: update items
 			this.virtualList.setItems(this.entries);
 		} else {
-			// Fragment mode: re-render
-			this.destroyChildTrees();
-			this.container.innerHTML = "";
-			this.renderWithFragment();
+			const index = this.entries.findIndex((item) => item.url === url);
+			const $el = this.createEntryElement(entry);
+			const $next = this.container.children[index];
+			this.container.insertBefore($el, $next || null);
 		}
 	}
 

--- a/src/components/inputhints/index.js
+++ b/src/components/inputhints/index.js
@@ -27,9 +27,11 @@ import "./style.scss";
  * @param {HTMLInputElement} $input Input field
  * @param {Array<Hint>|HintCallback} hints Hints or a callback to generate hints
  * @param {(value: string) => void} onSelect Callback to call when a hint is selected
+ * @param {object} [options]
+ * @param {boolean} [options.dynamic] Regenerate hints when input changes
  * @returns {{getSelected: ()=>HTMLLIElement, container: HTMLUListElement}}
  */
-export default function inputhints($input, hints, onSelect) {
+export default function inputhints($input, hints, onSelect, options = {}) {
 	/**@type {HTMLUListElement} */
 	const $ul = <Ul />;
 	const LIMIT = 100;
@@ -38,14 +40,26 @@ export default function inputhints($input, hints, onSelect) {
 	let updateUlTimeout;
 	let pages = 0;
 	let currentHints = [];
+	let hintProvider = null;
+	let dynamicUpdateTimeout = 0;
+	let dynamicUpdateVersion = 0;
 
 	$input.addEventListener("focus", onfocus);
 
 	if (typeof hints === "function") {
 		const cb = hints;
+		hintProvider = cb;
 		hints = [];
 		$ul.content = [<Hint hint={{ value: "", text: strings["loading..."] }} />];
-		cb(setHints, hintModification());
+		const version = ++dynamicUpdateVersion;
+		cb(
+			(list) => {
+				if (!options.dynamic || version === dynamicUpdateVersion)
+					setHints(list);
+			},
+			hintModification(),
+			"",
+		);
 	} else {
 		setHints(hints);
 	}
@@ -139,6 +153,21 @@ export default function inputhints($input, hints, onSelect) {
 	 */
 	function oninput() {
 		const { value: toTest } = this;
+		if (options.dynamic && hintProvider) {
+			clearTimeout(dynamicUpdateTimeout);
+			const version = ++dynamicUpdateVersion;
+			dynamicUpdateTimeout = setTimeout(() => {
+				hintProvider(
+					(list) => {
+						if (version === dynamicUpdateVersion) setHints(list);
+					},
+					hintModification(),
+					toTest,
+				);
+			}, 120);
+			return;
+		}
+
 		const matched = [];
 		const regexp = new RegExp(escapeRegExp(toTest), "i");
 		hints.forEach((hint) => {
@@ -171,6 +200,8 @@ export default function inputhints($input, hints, onSelect) {
 		if (preventUpdate) return;
 
 		clearTimeout(updateUlTimeout);
+		clearTimeout(dynamicUpdateTimeout);
+		dynamicUpdateVersion += 1;
 		$input.removeEventListener("keypress", handleKeypress);
 		$input.removeEventListener("keydown", handleKeydown);
 		$input.removeEventListener("blur", onblur);
@@ -215,6 +246,7 @@ export default function inputhints($input, hints, onSelect) {
 	 * @param {Array<Hint>} list Hint items
 	 */
 	function setHints(list) {
+		pages = 0;
 		if (Array.isArray(list)) {
 			hints = list;
 		} else {

--- a/src/components/palette/index.js
+++ b/src/components/palette/index.js
@@ -45,12 +45,20 @@ This shows that using keyboardHideStart event is faster than not using it.
  * @param {()=>string} onsSelectCb Callback to call when a hint is selected
  * @param {string} placeholder Placeholder for input
  * @param {function} onremove Callback to call when palette is removed
+ * @param {object} [options]
+ * @param {boolean} [options.dynamic] Regenerate hints when the query changes
  * @returns {void}
  */
 // Track active palette for chaining
 let activePalette = null;
 
-export default function palette(getList, onsSelectCb, placeholder, onremove) {
+export default function palette(
+	getList,
+	onsSelectCb,
+	placeholder,
+	onremove,
+	options = {},
+) {
 	// Store previous palette if exists
 	const previousPalette = activePalette;
 	const isChained = !!previousPalette;
@@ -69,7 +77,7 @@ export default function palette(getList, onsSelectCb, placeholder, onremove) {
 	const $palette = <div id="palette">{$input}</div>;
 
 	// Create a palette with input and hints
-	inputhints($input, generateHints, onSelect);
+	inputhints($input, generateHints, onSelect, options);
 
 	// Only set the darkened theme when this is not a chained palette
 	if (!isChained) {
@@ -137,8 +145,8 @@ export default function palette(getList, onsSelectCb, placeholder, onremove) {
 	 * @param {HintCallback} setHints Set hints callback
 	 * @param {HintModification} hintModification Hint modification object
 	 */
-	async function generateHints(setHints, hintModification) {
-		const list = getList(hintModification);
+	async function generateHints(setHints, hintModification, query) {
+		const list = getList(hintModification, query);
 		const data = list instanceof Promise ? await list : list;
 		setHints(data);
 	}

--- a/src/lib/acode.js
+++ b/src/lib/acode.js
@@ -51,6 +51,7 @@ import windowResize from "handlers/windowResize";
 import actionStack from "lib/actionStack";
 import commands from "lib/commands";
 import EditorFile from "lib/editorFile";
+import fileIndex from "lib/fileIndex";
 import files from "lib/fileList";
 import fileTypeHandler from "lib/fileTypeHandler";
 import fonts from "lib/fonts";
@@ -365,7 +366,21 @@ class Acode {
 		this.define("dialogBox", dialog);
 		this.define("prompt", prompt);
 		this.define("intent", intent);
-		this.define("fileList", files);
+		let didWarnAboutFileList = false;
+		const deprecatedFileList = (...args) => {
+			if (!didWarnAboutFileList) {
+				didWarnAboutFileList = true;
+				console.warn(
+					'acode.require("fileList") is deprecated. Use the asynchronous "fileIndex" API. fileList now contains only non-native storage providers.',
+				);
+			}
+			return files(...args);
+		};
+		Object.assign(deprecatedFileList, files);
+		deprecatedFileList.deprecated = true;
+		deprecatedFileList.replacement = "fileIndex";
+		this.define("fileList", deprecatedFileList);
+		this.define("fileIndex", fileIndex);
 		this.define("fs", fsOperation);
 		this.define("confirm", confirm);
 		this.define("helpers", helpers);

--- a/src/lib/fileIndex.js
+++ b/src/lib/fileIndex.js
@@ -1,0 +1,256 @@
+import settings from "./settings";
+
+const pendingScans = new Map();
+const scanIdsByRoot = new Map();
+const listeners = new Set();
+
+/**
+ * Whether a URL can be indexed by the Android native workspace index.
+ * Remote providers such as FTP and SFTP remain on the JavaScript fallback.
+ * @param {string} url
+ */
+export function supports(url = "") {
+	return (
+		typeof sdcard !== "undefined" &&
+		typeof sdcard.workspaceScan === "function" &&
+		(/^file:/.test(url) || /^content:/.test(url))
+	);
+}
+
+/**
+ * Scan a SAF or file:// workspace entirely on the native side.
+ * @param {string|object} root
+ * @param {object} [options]
+ * @returns {Promise<object> & {id: string, cancel: () => Promise<unknown>}}
+ */
+export function scan(root, options = {}) {
+	const rootUrl = typeof root === "string" ? root : root?.url;
+	const title =
+		typeof root === "string"
+			? options.title || options.name
+			: root?.name || root?.title;
+	if (!supports(rootUrl)) {
+		return Promise.reject(
+			new Error(`Native file index does not support: ${rootUrl}`),
+		);
+	}
+
+	cancelRootScan(rootUrl);
+	const id = `scan-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	scanIdsByRoot.set(rootUrl, id);
+
+	const promise = new Promise((resolve, reject) => {
+		sdcard.workspaceScan(
+			{
+				id,
+				rootUrl,
+				title,
+				excludeFolders: options.excludeFolders || settings.value.excludeFolders,
+				showHiddenFiles:
+					options.showHiddenFiles ??
+					!!settings.value.fileBrowser?.showHiddenFiles,
+				defaultEncoding:
+					options.defaultEncoding || settings.value.defaultFileEncoding,
+				indexContent: !!options.indexContent,
+				emitEntries: false,
+			},
+			(event) => {
+				emit(event);
+				switch (event?.type || event?.action) {
+					case "done":
+						scanIdsByRoot.delete(rootUrl);
+						resolve(event);
+						break;
+					case "cancelled":
+						scanIdsByRoot.delete(rootUrl);
+						resolve(event);
+						break;
+					case "error":
+						scanIdsByRoot.delete(rootUrl);
+						reject(new Error(event.error || "Native scan failed"));
+						break;
+				}
+			},
+			(error) => {
+				scanIdsByRoot.delete(rootUrl);
+				reject(normalizeError(error));
+			},
+		);
+	});
+
+	pendingScans.set(rootUrl, promise);
+	const cleanup = () => {
+		if (pendingScans.get(rootUrl) === promise) pendingScans.delete(rootUrl);
+	};
+	promise.then(cleanup, cleanup);
+	promise.id = id;
+	promise.cancel = () => cancel(id);
+	return promise;
+}
+
+/**
+ * Query indexed entries. Results are flat and paginated.
+ * @param {object} [options]
+ */
+export function query(options = {}) {
+	if (
+		typeof sdcard === "undefined" ||
+		typeof sdcard.workspaceQuery !== "function"
+	) {
+		return Promise.reject(new Error("Native file index is unavailable"));
+	}
+
+	return new Promise((resolve, reject) => {
+		sdcard.workspaceQuery(
+			{
+				roots: options.roots || [],
+				text: options.text || "",
+				url: options.url || "",
+				includeDirectories: !!options.includeDirectories,
+				limit: options.limit || 200,
+				cursor: options.cursor || 0,
+			},
+			resolve,
+			(error) => reject(normalizeError(error)),
+		);
+	});
+}
+
+/**
+ * Start a native streaming search.
+ * @param {object} options
+ * @param {(event: object) => void} [onEvent]
+ * @returns {{id: string, result: Promise<object>, cancel: () => Promise<unknown>}}
+ */
+export function search(options, onEvent = () => {}) {
+	if (
+		typeof sdcard === "undefined" ||
+		typeof sdcard.workspaceSearch !== "function"
+	) {
+		const error = Promise.reject(new Error("Native file index is unavailable"));
+		return { id: "", result: error, cancel: () => Promise.resolve() };
+	}
+
+	const id =
+		options?.id ||
+		`search-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+	const result = new Promise((resolve, reject) => {
+		sdcard.workspaceSearch(
+			{
+				...options,
+				id,
+				roots: options?.roots || [],
+				files: options?.files || [],
+				overlays: options?.overlays || {},
+				defaultEncoding:
+					options?.defaultEncoding || settings.value.defaultFileEncoding,
+			},
+			(event) => {
+				onEvent(event);
+				switch (event?.type || event?.action) {
+					case "done-searching":
+					case "done-replacing":
+						resolve(event);
+						break;
+					case "error":
+						reject(new Error(event.error || "Native search failed"));
+						break;
+				}
+			},
+			(error) => reject(normalizeError(error)),
+		);
+	});
+
+	return { id, result, cancel: () => cancel(id) };
+}
+
+/**
+ * Get one indexed entry by URL.
+ * @param {string} url
+ */
+export async function get(url) {
+	const { entries } = await query({ url, includeDirectories: true, limit: 1 });
+	return entries?.[0] || null;
+}
+
+/**
+ * Mark cached contents stale after an editor or filesystem change.
+ * @param {string[]} urls
+ */
+export function markDirty(urls) {
+	return callNative("workspaceMarkDirty", [urls || []]);
+}
+
+/**
+ * Remove one or more native workspace indexes.
+ * @param {string[]} roots
+ */
+export function clear(roots = []) {
+	roots.forEach(cancelRootScan);
+	return callNative("workspaceClear", [roots]);
+}
+
+/**
+ * Wait until all scans, or scans for selected roots, finish.
+ * @param {string[]} [roots]
+ */
+export function whenReady(roots) {
+	const scans = roots?.length
+		? roots.map((root) => pendingScans.get(root)).filter(Boolean)
+		: [...pendingScans.values()];
+	return Promise.allSettled(scans);
+}
+
+export function subscribe(listener) {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function cancel(id) {
+	if (!id) return Promise.resolve();
+	return callNative("workspaceCancel", [id]);
+}
+
+function cancelRootScan(rootUrl) {
+	const id = scanIdsByRoot.get(rootUrl);
+	if (!id) return;
+	scanIdsByRoot.delete(rootUrl);
+	try {
+		sdcard.workspaceCancel(id);
+	} catch (_) {
+		// Ignore cancellation failures; the replacement scan remains authoritative.
+	}
+}
+
+function emit(event) {
+	listeners.forEach((listener) => listener(event));
+}
+
+function callNative(method, args) {
+	if (typeof sdcard === "undefined" || typeof sdcard[method] !== "function") {
+		return Promise.reject(new Error("Native file index is unavailable"));
+	}
+	return new Promise((resolve, reject) => {
+		sdcard[method](...args, resolve, (error) => reject(normalizeError(error)));
+	});
+}
+
+function normalizeError(error) {
+	if (error instanceof Error) return error;
+	return new Error(error?.message || String(error));
+}
+
+const fileIndex = {
+	supports,
+	scan,
+	query,
+	search,
+	get,
+	markDirty,
+	clear,
+	whenReady,
+	subscribe,
+	cancel,
+};
+
+export default fileIndex;

--- a/src/lib/fileIndex.js
+++ b/src/lib/fileIndex.js
@@ -142,6 +142,7 @@ export function search(options, onEvent = () => {}) {
 				roots: options?.roots || [],
 				files: options?.files || [],
 				overlays: options?.overlays || {},
+				batchResults: options?.batchResults ?? true,
 				defaultEncoding:
 					options?.defaultEncoding || settings.value.defaultFileEncoding,
 			},

--- a/src/lib/fileIndex.js
+++ b/src/lib/fileIndex.js
@@ -58,21 +58,21 @@ export function scan(root, options = {}) {
 				emit(event);
 				switch (event?.type || event?.action) {
 					case "done":
-						scanIdsByRoot.delete(rootUrl);
+						clearScanId(rootUrl, id);
 						resolve(event);
 						break;
 					case "cancelled":
-						scanIdsByRoot.delete(rootUrl);
+						clearScanId(rootUrl, id);
 						resolve(event);
 						break;
 					case "error":
-						scanIdsByRoot.delete(rootUrl);
+						clearScanId(rootUrl, id);
 						reject(new Error(event.error || "Native scan failed"));
 						break;
 				}
 			},
 			(error) => {
-				scanIdsByRoot.delete(rootUrl);
+				clearScanId(rootUrl, id);
 				reject(normalizeError(error));
 			},
 		);
@@ -86,6 +86,39 @@ export function scan(root, options = {}) {
 	promise.id = id;
 	promise.cancel = () => cancel(id);
 	return promise;
+}
+
+/**
+ * Incrementally refresh changed files or directory subtrees in a native index.
+ * @param {string|object} root
+ * @param {object} changes
+ * @param {{url: string, parentUrl: string}[]} [changes.added]
+ * @param {string[]} [changes.removed]
+ */
+export function update(root, changes = {}) {
+	const rootUrl = typeof root === "string" ? root : root?.url;
+	const title =
+		typeof root === "string" ? changes.title || changes.name : root?.title;
+	if (!supports(rootUrl)) {
+		return Promise.reject(
+			new Error(`Native file index does not support: ${rootUrl}`),
+		);
+	}
+
+	return callNative("workspaceUpdate", [
+		{
+			rootUrl,
+			title,
+			added: changes.added || [],
+			removed: changes.removed || [],
+			excludeFolders: changes.excludeFolders || settings.value.excludeFolders,
+			showHiddenFiles:
+				changes.showHiddenFiles ??
+				!!settings.value.fileBrowser?.showHiddenFiles,
+			defaultEncoding:
+				changes.defaultEncoding || settings.value.defaultFileEncoding,
+		},
+	]);
 }
 
 /**
@@ -215,11 +248,17 @@ export function cancel(id) {
 function cancelRootScan(rootUrl) {
 	const id = scanIdsByRoot.get(rootUrl);
 	if (!id) return;
-	scanIdsByRoot.delete(rootUrl);
+	clearScanId(rootUrl, id);
 	try {
 		sdcard.workspaceCancel(id);
 	} catch (_) {
 		// Ignore cancellation failures; the replacement scan remains authoritative.
+	}
+}
+
+function clearScanId(rootUrl, id) {
+	if (scanIdsByRoot.get(rootUrl) === id) {
+		scanIdsByRoot.delete(rootUrl);
 	}
 }
 
@@ -244,6 +283,7 @@ function normalizeError(error) {
 const fileIndex = {
 	supports,
 	scan,
+	update,
 	query,
 	search,
 	get,

--- a/src/lib/fileList.js
+++ b/src/lib/fileList.js
@@ -2,10 +2,14 @@ import fsOperation from "fileSystem";
 import toast from "components/toast";
 import picomatch from "picomatch/posix";
 import Url from "utils/Url";
+import fileIndex from "./fileIndex";
 import { addedFolder } from "./openFolder";
 import settings from "./settings";
 
 /**
+ * @deprecated Native SAF and file:// workspaces are available through fileIndex.
+ * This module now maintains the compatibility index for non-native providers.
+ *
  * @typedef {import('fileSystem').File} File
  */
 
@@ -36,6 +40,13 @@ export function initFileList() {
  * @param {string} child file url
  */
 export async function append(parent, child) {
+	const nativeRoot = findNativeRoot(parent);
+	if (nativeRoot) {
+		fileIndex.markDirty([child]).catch(() => {});
+		fileIndex.scan(nativeRoot).catch(logNativeIndexError);
+		return;
+	}
+
 	const tree = getTree(Object.values(filesTree), parent);
 	if (!tree || !tree.children) return;
 
@@ -50,6 +61,23 @@ export async function append(parent, child) {
  * @param {string} item url
  */
 export function remove(item) {
+	const nativeRoot = findNativeRoot(item);
+	if (nativeRoot) {
+		if (nativeRoot.url === item) {
+			fileIndex.clear([item]).then(
+				() => emit("remove-folder", { url: item, native: true }),
+				(error) => {
+					logNativeIndexError(error);
+					emit("remove-folder", { url: item, native: true });
+				},
+			);
+		} else {
+			fileIndex.markDirty([item]).catch(() => {});
+			fileIndex.scan(nativeRoot).catch(logNativeIndexError);
+		}
+		return;
+	}
+
 	if (filesTree[item]) {
 		removeRootTree(item);
 		emit("remove-file", item);
@@ -82,18 +110,24 @@ export async function refresh() {
 	});
 
 	await Promise.all(
-		addedFolder.map(async ({ url, title }) => {
-			const tree = await Tree.createRoot(url, title);
-			filesTree[url] = tree;
-			trackScan(getAllFiles(tree));
-		}),
+		addedFolder
+			.filter(({ listFiles }) => listFiles)
+			.map(async ({ url, title }) => {
+				if (fileIndex.supports(url)) {
+					await fileIndex.scan({ url, name: title });
+					return;
+				}
+				const tree = await Tree.createRoot(url, title);
+				filesTree[url] = tree;
+				trackScan(getAllFiles(tree));
+			}),
 	);
 
 	emit("refresh", filesTree);
 }
 
 export async function whenReady() {
-	await Promise.all([...pendingScans]);
+	await Promise.allSettled([...pendingScans, fileIndex.whenReady()]);
 }
 
 /**
@@ -103,6 +137,13 @@ export async function whenReady() {
  * @returns
  */
 export function rename(oldUrl, newUrl) {
+	const nativeRoot = findNativeRoot(oldUrl) || findNativeRoot(newUrl);
+	if (nativeRoot) {
+		fileIndex.markDirty([oldUrl, newUrl]).catch(() => {});
+		fileIndex.scan(nativeRoot).catch(logNativeIndexError);
+		return;
+	}
+
 	const tree = getTree(Object.values(filesTree), oldUrl);
 	if (!tree) return;
 
@@ -234,6 +275,11 @@ export async function addRoot({ url, name }) {
 			"content://com.termux.documents/tree/%2Fdata%2Fdata%2Fcom.termux%2Ffiles%2Fhome::/data/data/com.termux/files/home/storage/shared";
 		if (url === TERMUX_STORAGE) return;
 		if (url === TERMUX_SHARED) return;
+		if (fileIndex.supports(url)) {
+			await fileIndex.scan({ url, name });
+			emit("add-folder", { url, name, native: true });
+			return;
+		}
 
 		const tree = await Tree.createRoot(url, name);
 		filesTree[url] = tree;
@@ -265,10 +311,6 @@ async function getAllFiles(parent, root, options = {}) {
 	root = root || parent.root;
 	if (!parent.children || !root.isConnected) return;
 
-	if (supportsNativeWorkspace(root.url)) {
-		return getAllFilesNative(parent, root, options);
-	}
-
 	try {
 		const entries = await fsOperation(parent.url).lsDir();
 		const promises = [];
@@ -295,93 +337,6 @@ async function getAllFiles(parent, root, options = {}) {
 	}
 }
 
-function supportsNativeWorkspace(url = "") {
-	return (
-		typeof sdcard !== "undefined" &&
-		typeof sdcard.workspaceScan === "function" &&
-		(/^file:/.test(url) || /^content:/.test(url))
-	);
-}
-
-async function getAllFilesNative(parent, root, options = {}) {
-	const id = `scan-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-
-	return new Promise((resolve, reject) => {
-		let settled = false;
-
-		const finish = (fn, value) => {
-			if (settled) return;
-			settled = true;
-			fn(value);
-		};
-
-		const cancelIfDisconnected = () => {
-			if (root.isConnected) return false;
-			try {
-				sdcard.workspaceCancel(id);
-			} catch (_) {
-				// ignore cancellation failures
-			}
-			finish(resolve);
-			return true;
-		};
-
-		sdcard.workspaceScan(
-			{
-				id,
-				rootUrl: parent.url,
-				title: parent.name,
-				excludeFolders: settings.value.excludeFolders,
-				showHiddenFiles: !!settings.value.fileBrowser?.showHiddenFiles,
-				defaultEncoding: settings.value.defaultFileEncoding,
-				indexContent: !!options.indexContent,
-			},
-			(event) => {
-				if (cancelIfDisconnected()) return;
-				switch (event?.type || event?.action) {
-					case "batch":
-						addNativeEntries(root, event.entries || []);
-						break;
-					case "done":
-						finish(resolve);
-						break;
-					case "error":
-						finish(reject, new Error(event.error || "Native scan failed"));
-						break;
-				}
-			},
-			(error) => {
-				finish(reject, error);
-			},
-		);
-	});
-}
-
-function addNativeEntries(root, entries) {
-	for (const item of entries) {
-		const parentUrl = item.parentUrl || item.parent;
-		const parentTree =
-			parentUrl === root.url ? root : getTree([root], parentUrl);
-		if (!parentTree?.children) continue;
-		if (parentTree.children.find(({ url }) => url === item.url)) continue;
-
-		const file = new Tree(
-			item.name,
-			item.url,
-			item.isDirectory,
-			item.mime || item.type,
-			item.size,
-			item.modifiedDate,
-		);
-		parentTree.children.push(file);
-
-		if (!file.children) {
-			emit("push-file", file);
-			emit("add-file", file);
-		}
-	}
-}
-
 /**
  * Emit an event
  * @param {string} event
@@ -395,7 +350,8 @@ function emit(event, ...args) {
 
 function trackScan(scan) {
 	pendingScans.add(scan);
-	scan.finally(() => pendingScans.delete(scan));
+	const cleanup = () => pendingScans.delete(scan);
+	scan.then(cleanup, cleanup);
 	return scan;
 }
 
@@ -642,4 +598,21 @@ function normalizeModifiedDate(value) {
 	if (typeof value === "number") return value;
 	const time = new Date(value).getTime();
 	return Number.isNaN(time) ? 0 : time;
+}
+
+function findNativeRoot(url) {
+	if (!url) return null;
+	return addedFolder.find(({ url: rootUrl }) => {
+		if (!fileIndex.supports(rootUrl)) return false;
+		const prefix = rootUrl.endsWith("/") ? rootUrl : `${rootUrl}/`;
+		return (
+			url === rootUrl ||
+			url.startsWith(prefix) ||
+			url.startsWith(`${rootUrl}::`)
+		);
+	});
+}
+
+function logNativeIndexError(error) {
+	console.error("Native workspace index update failed:", error);
 }

--- a/src/lib/fileList.js
+++ b/src/lib/fileList.js
@@ -42,8 +42,11 @@ export function initFileList() {
 export async function append(parent, child) {
 	const nativeRoot = findNativeRoot(parent);
 	if (nativeRoot) {
-		fileIndex.markDirty([child]).catch(() => {});
-		fileIndex.scan(nativeRoot).catch(logNativeIndexError);
+		fileIndex
+			.update(nativeRoot, {
+				added: [{ url: child, parentUrl: parent }],
+			})
+			.catch(logNativeIndexError);
 		return;
 	}
 
@@ -72,8 +75,9 @@ export function remove(item) {
 				},
 			);
 		} else {
-			fileIndex.markDirty([item]).catch(() => {});
-			fileIndex.scan(nativeRoot).catch(logNativeIndexError);
+			fileIndex
+				.update(nativeRoot, { removed: [item] })
+				.catch(logNativeIndexError);
 		}
 		return;
 	}
@@ -139,8 +143,12 @@ export async function whenReady() {
 export function rename(oldUrl, newUrl) {
 	const nativeRoot = findNativeRoot(oldUrl) || findNativeRoot(newUrl);
 	if (nativeRoot) {
-		fileIndex.markDirty([oldUrl, newUrl]).catch(() => {});
-		fileIndex.scan(nativeRoot).catch(logNativeIndexError);
+		fileIndex
+			.update(nativeRoot, {
+				removed: [oldUrl],
+				added: [{ url: newUrl, parentUrl: Url.dirname(newUrl) }],
+			})
+			.catch(logNativeIndexError);
 		return;
 	}
 
@@ -602,7 +610,8 @@ function normalizeModifiedDate(value) {
 
 function findNativeRoot(url) {
 	if (!url) return null;
-	return addedFolder.find(({ url: rootUrl }) => {
+	return addedFolder.find(({ url: rootUrl, listFiles }) => {
+		if (!listFiles) return false;
 		if (!fileIndex.supports(rootUrl)) return false;
 		const prefix = rootUrl.endsWith("/") ? rootUrl : `${rootUrl}/`;
 		return (

--- a/src/lib/openFolder.js
+++ b/src/lib/openFolder.js
@@ -215,9 +215,9 @@ function openFolder(_path, opts = {}) {
 			$root.remove();
 		}
 
+		FileList.remove(_path);
 		const index = addedFolder.findIndex((folder) => folder.url === _path);
 		if (index !== -1) addedFolder.splice(index, 1);
-		FileList.remove(_path);
 		editorManager.emit("update", "remove-folder");
 		editorManager.onupdate("remove-folder", event);
 		editorManager.emit("remove-folder", event);

--- a/src/lib/openFolder.js
+++ b/src/lib/openFolder.js
@@ -281,22 +281,6 @@ async function expandList($list) {
 }
 
 /**
- * Gets weather the folder is collapsed or not
- * @param {HTMLElement} $el
- * @param {boolean} isFile
- * @returns
- */
-function collapsed($el, isFile) {
-	if (!$el.isConnected) return true;
-	$el = $el.parentElement;
-	if (!isFile) {
-		$el = $el.parentElement;
-	}
-
-	return $el.previousElementSibling.collapsed;
-}
-
-/**
  * Handle click event
  * @param {Event} e
  */
@@ -692,7 +676,7 @@ function execOperation(type, action, url, $target, name) {
 
 			if (isNestedPath) {
 				await refreshOpenFolder(url);
-				await FileList.refresh();
+				FileList.append(newUrl.parentUri, newUrl.uri);
 				toast(strings.success);
 				return;
 			}
@@ -736,16 +720,9 @@ function execOperation(type, action, url, $target, name) {
 			}
 		}
 
-		let CASE = "";
-		const $src = clipBoard.$el;
-		const srcType = $src.dataset.type;
+		const srcType = clipBoard.$el.dataset.type;
 		const IS_FILE = helpers.isFile(srcType);
 		const IS_DIR = helpers.isDir(srcType);
-		const srcCollapsed = collapsed($src, IS_FILE);
-
-		CASE += IS_FILE ? 1 : 0;
-		CASE += srcCollapsed ? 1 : 0;
-		CASE += $target.collapsed ? 1 : 0;
 
 		startLoading();
 		try {
@@ -801,91 +778,23 @@ function execOperation(type, action, url, $target, name) {
 			} else {
 				newUrl = await fs.copyTo(url);
 			}
-			const { name: newName } = await fsOperation(newUrl).stat();
 			stopLoading();
-			/**
-			 * CASES:
-			 * CASE 111: src is file and parent is collapsed where target is also collapsed
-			 * CASE 110: src is file and parent is collapsed where target is unclasped
-			 * CASE 101: src is file and parent is unclasped where target is collapsed
-			 * CASE 100: src is file and parent is unclasped where target is also unclasped
-			 * CASE 011: src is directory and parent is collapsed where target is also collapsed
-			 * CASE 001: src is directory and parent is unclasped where target is also collapsed
-			 * CASE 010: src is directory and parent is collapsed where target is also unclasped
-			 * CASE 000: src is directory and parent is unclasped where target is also unclasped
-			 */
 
 			if (clipBoard.action === "cut") {
-				//move
-
 				if (IS_FILE) {
 					const file = editorManager.getFile(clipBoard.url, "uri");
 					if (file) file.uri = newUrl;
 				} else if (IS_DIR) {
 					helpers.updateUriOfAllActiveFiles(clipBoard.url, newUrl);
+					migrateOpenFolderStateUrls(clipBoard.url, newUrl);
 				}
-
-				switch (CASE) {
-					case "111":
-					case "011":
-						break;
-
-					case "110":
-						appendTile($target, createFileTile(newName, newUrl));
-						break;
-
-					case "101":
-						$src.remove();
-						break;
-
-					case "100":
-						appendTile($target, createFileTile(newName, newUrl));
-						$src.remove();
-						break;
-
-					case "001":
-						$src.parentElement.remove();
-						break;
-
-					case "010":
-						appendList($target, createFolderTile(newName, newUrl));
-						break;
-
-					case "000":
-						appendList($target, createFolderTile(newName, newUrl));
-						$src.parentElement.remove();
-						break;
-
-					default:
-						break;
-				}
-				FileList.remove(clipBoard.url);
+				removeEntryFromOpenFolder(clipBoard.url);
+				FileList.rename(clipBoard.url, newUrl);
 			} else {
-				//copy
-
-				switch (CASE) {
-					case "111":
-					case "101":
-					case "011":
-					case "001":
-						break;
-
-					case "110":
-					case "100":
-						appendTile($target, createFileTile(newName, newUrl));
-						break;
-
-					case "010":
-					case "000":
-						appendList($target, createFolderTile(newName, newUrl));
-						break;
-
-					default:
-						break;
-				}
+				FileList.append(url, newUrl);
 			}
 
-			FileList.append(url, newUrl);
+			appendEntryToOpenFolder(url, newUrl, IS_DIR ? "folder" : "file");
 			toast(strings.success);
 			clearClipboard();
 		} catch (error) {

--- a/src/palettes/findFile/index.js
+++ b/src/palettes/findFile/index.js
@@ -1,6 +1,8 @@
 import palette from "components/palette";
+import fileIndex from "lib/fileIndex";
 import files from "lib/fileList";
 import openFile from "lib/openFile";
+import { addedFolder } from "lib/openFolder";
 import recents from "lib/recents";
 import helpers from "utils/helpers";
 
@@ -12,10 +14,16 @@ import helpers from "utils/helpers";
 let hintsModification;
 
 export default async function findFile() {
-	palette(generateHints, onselect, strings["type filename"], () => {
-		files.off("add-file", onAddFile);
-		files.off("remove-file", onRemoveFile);
-	});
+	palette(
+		generateHints,
+		onselect,
+		strings["type filename"],
+		() => {
+			files.off("add-file", onAddFile);
+			files.off("remove-file", onRemoveFile);
+		},
+		{ dynamic: true },
+	);
 
 	files.on("add-file", onAddFile);
 	files.on("remove-file", onRemoveFile);
@@ -24,22 +32,51 @@ export default async function findFile() {
 	 * Generates hint for inputhints
 	 * @param {HintModification} hints Hint modification object
 	 */
-	async function generateHints(hints) {
+	async function generateHints(hints, query = "") {
 		hintsModification = hints;
 		const list = [];
+		const seen = new Set();
 
 		editorManager.files.forEach((file) => {
 			const { uri, name } = file;
+			if (!matchesQuery(query, name, uri)) return;
 			let { location = "" } = file;
 
 			if (location) {
 				location = helpers.getVirtualPath(location);
 			}
 
+			if (uri) seen.add(uri);
 			list.push(hintItem(name, location, uri));
 		});
 
-		list.push(...files(hintItem));
+		files().forEach((file) => {
+			if (seen.has(file.url)) return;
+			if (!matchesQuery(query, file.name, file.path)) return;
+			seen.add(file.url);
+			list.push(hintItem(file));
+		});
+
+		const nativeRoots = addedFolder
+			.filter(({ listFiles }) => listFiles)
+			.map(({ url }) => url)
+			.filter((url) => fileIndex.supports(url));
+		if (nativeRoots.length) {
+			try {
+				const { entries = [] } = await fileIndex.query({
+					roots: nativeRoots,
+					text: query,
+					limit: 300,
+				});
+				entries.forEach((file) => {
+					if (seen.has(file.url)) return;
+					seen.add(file.url);
+					list.push(hintItem(file));
+				});
+			} catch (error) {
+				console.warn("Unable to query native file index:", error);
+			}
+		}
 		return list;
 	}
 
@@ -47,6 +84,16 @@ export default async function findFile() {
 		if (!value) return;
 		openFile(value);
 	}
+}
+
+function matchesQuery(query, ...values) {
+	if (!query) return true;
+	const normalized = query.toLowerCase();
+	return values.some((value) =>
+		String(value || "")
+			.toLowerCase()
+			.includes(normalized),
+	);
 }
 
 /**

--- a/src/plugins/sdcard/index.d.ts
+++ b/src/plugins/sdcard/index.d.ts
@@ -59,6 +59,7 @@ type WorkspaceEvent =
   | { id: string; type: 'status'; action: 'status'; state: string; message: string; progress: number }
   | { id: string; type: 'batch'; action: 'batch'; entries: WorkspaceFileEntry[] }
   | { id: string; type: 'search-result'; action: 'search-result'; data: any }
+  | { id: string; type: 'search-results'; action: 'search-results'; data: any[] }
   | { id: string; type: 'replace-result'; action: 'replace-result'; file: WorkspaceFileEntry; text: string }
   | { id: string; type: 'progress'; action: 'progress'; data: number }
   | { id: string; type: 'done' | 'done-searching' | 'done-replacing' | 'error'; action: string; [key: string]: any };

--- a/src/plugins/sdcard/index.d.ts
+++ b/src/plugins/sdcard/index.d.ts
@@ -291,6 +291,15 @@ interface SDcard {
     onEvent: (event: WorkspaceEvent) => void,
     onFail: (err: any) => void,
   ): void;
+  workspaceQuery(
+    options: any,
+    onSuccess: (result: {
+      entries: any[];
+      cursor: number | null;
+      hasMore: boolean;
+    }) => void,
+    onFail: (err: any) => void,
+  ): void;
   workspaceCancel(
     id: string,
     onSuccess?: (res: 'OK') => void,

--- a/src/plugins/sdcard/index.d.ts
+++ b/src/plugins/sdcard/index.d.ts
@@ -287,6 +287,14 @@ interface SDcard {
     onEvent: (event: WorkspaceEvent) => void,
     onFail: (err: any) => void,
   ): void;
+  workspaceUpdate(
+    options: any,
+    onSuccess: (result: {
+      added: number;
+      removed: number;
+    }) => void,
+    onFail: (err: any) => void,
+  ): void;
   workspaceSearch(
     options: any,
     onEvent: (event: WorkspaceEvent) => void,

--- a/src/plugins/sdcard/src/android/SDcard.java
+++ b/src/plugins/sdcard/src/android/SDcard.java
@@ -177,6 +177,12 @@ public class SDcard extends CordovaPlugin {
           callback
         );
         break;
+      case "workspace query":
+        workspaceIndex.query(
+          args.optJSONObject(0) == null ? new JSONObject() : args.optJSONObject(0),
+          callback
+        );
+        break;
       case "workspace cancel":
         workspaceIndex.cancel(arg1);
         callback.success("OK");

--- a/src/plugins/sdcard/src/android/SDcard.java
+++ b/src/plugins/sdcard/src/android/SDcard.java
@@ -171,6 +171,12 @@ public class SDcard extends CordovaPlugin {
           callback
         );
         break;
+      case "workspace update":
+        workspaceIndex.update(
+          args.optJSONObject(0) == null ? new JSONObject() : args.optJSONObject(0),
+          callback
+        );
+        break;
       case "workspace search":
         workspaceIndex.search(
           args.optJSONObject(0) == null ? new JSONObject() : args.optJSONObject(0),

--- a/src/plugins/sdcard/src/android/WorkspaceIndex.java
+++ b/src/plugins/sdcard/src/android/WorkspaceIndex.java
@@ -41,7 +41,7 @@ import org.json.JSONObject;
 class WorkspaceIndex {
   private static final String TAG = "WorkspaceIndex";
   private static final String SEPARATOR = "::";
-  private static final int DB_VERSION = 1;
+  private static final int DB_VERSION = 2;
   private static final int BATCH_SIZE = 200;
   private static final int MAX_INDEXED_CHARS = 512 * 1024;
   private static final int INDEX_READ_LIMIT_BYTES = MAX_INDEXED_CHARS * 4;
@@ -244,6 +244,18 @@ class WorkspaceIndex {
     );
   }
 
+  void query(JSONObject options, CallbackContext callback) {
+    executor.execute(
+      () -> {
+        try {
+          callback.success(runQuery(options));
+        } catch (Exception error) {
+          callback.error(error.getMessage() == null ? error.toString() : error.getMessage());
+        }
+      }
+    );
+  }
+
   void cancel(String id) {
     Job job = jobs.get(id);
     if (job != null) job.cancelled = true;
@@ -284,6 +296,7 @@ class WorkspaceIndex {
     boolean showHiddenFiles = options.optBoolean("showHiddenFiles", false);
     String defaultEncoding = options.optString("defaultEncoding", "UTF-8");
     boolean indexContent = options.optBoolean("indexContent", false);
+    boolean emitEntries = options.optBoolean("emitEntries", true);
 
     JSONArray batch = new JSONArray();
     ScanStats stats = new ScanStats();
@@ -316,6 +329,7 @@ class WorkspaceIndex {
           showHiddenFiles,
           defaultEncoding,
           indexContent,
+          emitEntries,
           batch,
           stats
         );
@@ -333,13 +347,17 @@ class WorkspaceIndex {
           showHiddenFiles,
           defaultEncoding,
           indexContent,
+          emitEntries,
           batch,
           stats
         );
       }
 
-      if (job.cancelled) return;
-      flushBatch(callback, job.id, batch);
+      if (job.cancelled) {
+        send(callback, baseEvent(job.id, "cancelled"), false);
+        return;
+      }
+      if (emitEntries) flushBatch(callback, job.id, batch);
       writable.setTransactionSuccessful();
     } finally {
       writable.endTransaction();
@@ -364,11 +382,18 @@ class WorkspaceIndex {
     boolean showHiddenFiles,
     String defaultEncoding,
     boolean indexContent,
+    boolean emitEntries,
     JSONArray batch,
     ScanStats stats
   ) throws Exception {
     if (job.cancelled || dir == null) return;
-    File[] children = dir.listFiles();
+    File[] children;
+    try {
+      children = dir.listFiles();
+    } catch (Exception error) {
+      Log.d(TAG, "Skipping unreadable directory " + dir, error);
+      return;
+    }
     if (children == null) return;
 
     for (File child : children) {
@@ -392,24 +417,29 @@ class WorkspaceIndex {
         child.lastModified()
       );
 
-      addEntry(callback, job.id, batch, entry, stats);
+      addEntry(callback, job.id, batch, entry, stats, emitEntries);
       if (isDir) {
-        if (isExcluded(path, exclude)) continue;
-        scanFileDir(
-          job,
-          callback,
-          rootUrl,
-          child,
-          url,
-          path,
-          title,
-          exclude,
-          showHiddenFiles,
-          defaultEncoding,
-          indexContent,
-          batch,
-          stats
-        );
+        if (shouldSkipDirectory(rootUrl, url, path, exclude)) continue;
+        try {
+          scanFileDir(
+            job,
+            callback,
+            rootUrl,
+            child,
+            url,
+            path,
+            title,
+            exclude,
+            showHiddenFiles,
+            defaultEncoding,
+            indexContent,
+            emitEntries,
+            batch,
+            stats
+          );
+        } catch (Exception error) {
+          Log.d(TAG, "Skipping unreadable directory " + url, error);
+        }
       } else {
         if (indexContent) {
           indexFile(entry, defaultEncoding);
@@ -432,6 +462,7 @@ class WorkspaceIndex {
     boolean showHiddenFiles,
     String defaultEncoding,
     boolean indexContent,
+    boolean emitEntries,
     JSONArray batch,
     ScanStats stats
   ) throws Exception {
@@ -442,20 +473,25 @@ class WorkspaceIndex {
     );
     Cursor cursor = null;
     try {
-      cursor =
-        resolver.query(
-          childrenUri,
-          new String[] {
-            Document.COLUMN_DOCUMENT_ID,
-            Document.COLUMN_DISPLAY_NAME,
-            Document.COLUMN_MIME_TYPE,
-            Document.COLUMN_SIZE,
-            Document.COLUMN_LAST_MODIFIED,
-          },
-          null,
-          null,
-          null
-        );
+      try {
+        cursor =
+          resolver.query(
+            childrenUri,
+            new String[] {
+              Document.COLUMN_DOCUMENT_ID,
+              Document.COLUMN_DISPLAY_NAME,
+              Document.COLUMN_MIME_TYPE,
+              Document.COLUMN_SIZE,
+              Document.COLUMN_LAST_MODIFIED,
+            },
+            null,
+            null,
+            null
+          );
+      } catch (Exception error) {
+        Log.d(TAG, "Skipping unreadable SAF directory " + parentUrl, error);
+        return;
+      }
       if (cursor == null) return;
 
       while (cursor.moveToNext()) {
@@ -483,25 +519,30 @@ class WorkspaceIndex {
           modified
         );
 
-        addEntry(callback, job.id, batch, entry, stats);
+        addEntry(callback, job.id, batch, entry, stats, emitEntries);
         if (isDir) {
-          if (isExcluded(path, exclude)) continue;
-          scanSafDir(
-            job,
-            callback,
-            treeUrl,
-            rootUrl,
-            docId,
-            url,
-            path,
-            title,
-            exclude,
-            showHiddenFiles,
-            defaultEncoding,
-            indexContent,
-            batch,
-            stats
-          );
+          if (shouldSkipDirectory(rootUrl, url, path, exclude)) continue;
+          try {
+            scanSafDir(
+              job,
+              callback,
+              treeUrl,
+              rootUrl,
+              docId,
+              url,
+              path,
+              title,
+              exclude,
+              showHiddenFiles,
+              defaultEncoding,
+              indexContent,
+              emitEntries,
+              batch,
+              stats
+            );
+          } catch (Exception error) {
+            Log.d(TAG, "Skipping unreadable SAF directory " + url, error);
+          }
         } else {
           if (indexContent) {
             indexFile(entry, defaultEncoding);
@@ -509,6 +550,8 @@ class WorkspaceIndex {
           }
         }
       }
+    } catch (Exception error) {
+      Log.d(TAG, "Stopping unreadable SAF directory " + parentUrl, error);
     } finally {
       if (cursor != null) cursor.close();
     }
@@ -519,14 +562,84 @@ class WorkspaceIndex {
     String id,
     JSONArray batch,
     FileEntry entry,
-    ScanStats stats
+    ScanStats stats,
+    boolean emitEntries
   ) throws Exception {
     saveFile(entry);
-    batch.put(entry.toJSON());
     if (entry.isDirectory) stats.dirs += 1; else stats.files += 1;
+    if (!emitEntries) return;
+    batch.put(entry.toJSON());
     if (batch.length() >= BATCH_SIZE) {
       flushBatch(callback, id, batch);
     }
+  }
+
+  private JSONObject runQuery(JSONObject options) throws Exception {
+    JSONArray roots = options.optJSONArray("roots");
+    String text = options.optString("text", "").trim();
+    String url = options.optString("url", "");
+    boolean includeDirectories = options.optBoolean("includeDirectories", false);
+    int limit = Math.max(1, Math.min(options.optInt("limit", 200), 1000));
+    int offset = Math.max(0, options.optInt("cursor", options.optInt("offset", 0)));
+
+    StringBuilder where = new StringBuilder("1 = 1");
+    List<String> args = new ArrayList<>();
+    appendRootsClause(where, args, roots);
+    if (url.length() > 0) {
+      where.append(" AND url = ?");
+      args.add(url);
+    }
+    if (!includeDirectories) {
+      where.append(" AND is_directory = 0");
+    }
+    if (text.length() > 0) {
+      where.append(" AND (name LIKE ? ESCAPE '\\' OR path LIKE ? ESCAPE '\\')");
+      String pattern = "%" + escapeLike(text) + "%";
+      args.add(pattern);
+      args.add(pattern);
+    }
+
+    String order;
+    if (text.length() > 0) {
+      order =
+        "CASE WHEN name LIKE ? ESCAPE '\\' THEN 0 ELSE 1 END, " +
+        "name COLLATE NOCASE, path COLLATE NOCASE";
+      args.add(escapeLike(text) + "%");
+    } else {
+      order = "name COLLATE NOCASE, path COLLATE NOCASE";
+    }
+
+    String sql =
+      "SELECT root_url, parent_url, url, name, path, mime, is_directory, size, modified_date " +
+      "FROM files WHERE " +
+      where +
+      " ORDER BY " +
+      order +
+      " LIMIT ? OFFSET ?";
+    args.add(String.valueOf(limit + 1));
+    args.add(String.valueOf(offset));
+
+    JSONArray entries = new JSONArray();
+    Cursor cursor = null;
+    boolean hasMore = false;
+    try {
+      cursor = db.getReadableDatabase().rawQuery(sql, args.toArray(new String[0]));
+      while (cursor.moveToNext()) {
+        if (entries.length() >= limit) {
+          hasMore = true;
+          break;
+        }
+        entries.put(fileEntryFromCursor(cursor).toJSON());
+      }
+    } finally {
+      if (cursor != null) cursor.close();
+    }
+
+    JSONObject result = new JSONObject();
+    result.put("entries", entries);
+    result.put("cursor", hasMore ? offset + entries.length() : JSONObject.NULL);
+    result.put("hasMore", hasMore);
+    return result;
   }
 
   private void flushBatch(CallbackContext callback, String id, JSONArray batch)
@@ -542,6 +655,7 @@ class WorkspaceIndex {
     throws Exception {
     JSONArray files = options.optJSONArray("files");
     if (files == null) files = new JSONArray();
+    files = mergeIndexedFiles(files, options.optJSONArray("roots"));
     String search = options.optString("search", "");
     String replace = options.optString("replace", null);
     String mode = options.optString("mode", "search");
@@ -555,21 +669,18 @@ class WorkspaceIndex {
     Pattern pattern = compileSearchPattern(search, searchOptions);
     int total = files.length();
     int processed = 0;
+    int lastProgress = -1;
 
     sendStatus(callback, job.id, "searching", "Searching files", 0, true);
 
     for (int i = 0; i < total; i++) {
       if (job.cancelled) return;
       JSONObject file = files.getJSONObject(i);
-      sendProgress(callback, job.id, total == 0 ? 100 : (processed * 100) / total);
-      sendStatus(
-        callback,
-        job.id,
-        "searching",
-        "Searching " + file.optString("name", "file"),
-        total == 0 ? 100 : (processed * 100) / total,
-        true
-      );
+      int progress = total == 0 ? 100 : (processed * 100) / total;
+      if (progress != lastProgress) {
+        sendProgress(callback, job.id, progress);
+        lastProgress = progress;
+      }
       if (!isSupportedUrl(file.optString("url"))) {
         processed += 1;
         continue;
@@ -580,17 +691,25 @@ class WorkspaceIndex {
       }
 
       boolean allowLargeFile = isExplicitlyIncluded(file, searchOptions);
-      String content = getFileContent(
-        file,
-        overlays,
-        defaultEncoding,
-        useIndex,
-        allowLargeFile,
-        callback,
-        job.id,
-        total,
-        processed
-      );
+      String content;
+      try {
+        content =
+          getFileContent(
+            file,
+            overlays,
+            defaultEncoding,
+            useIndex,
+            allowLargeFile,
+            callback,
+            job.id,
+            total,
+            processed
+          );
+      } catch (Exception error) {
+        Log.d(TAG, "Skipping unreadable search file " + file.optString("url"), error);
+        processed += 1;
+        continue;
+      }
       if (content == null) {
         processed += 1;
         sendProgress(callback, job.id, total == 0 ? 100 : (processed * 100) / total);
@@ -891,6 +1010,115 @@ class WorkspaceIndex {
     values.put("indexed_at", System.currentTimeMillis());
     values.put("skipped_reason", isBinary(entry) ? "binary" : null);
     db.getWritableDatabase().replace("files", null, values);
+  }
+
+  private JSONArray mergeIndexedFiles(JSONArray explicitFiles, JSONArray roots)
+    throws JSONException {
+    JSONArray result = new JSONArray();
+    Set<String> seen = new HashSet<>();
+    for (int i = 0; i < explicitFiles.length(); i++) {
+      JSONObject file = explicitFiles.optJSONObject(i);
+      if (file == null) continue;
+      String url = file.optString("url", "");
+      if (url.length() == 0 || !seen.add(url)) continue;
+      result.put(file);
+    }
+
+    if (roots == null || roots.length() == 0) return result;
+
+    StringBuilder where = new StringBuilder("is_directory = 0");
+    List<String> args = new ArrayList<>();
+    appendRootsClause(where, args, roots);
+    Cursor cursor = null;
+    try {
+      cursor =
+        db
+          .getReadableDatabase()
+          .query(
+            "files",
+            new String[] {
+              "root_url",
+              "parent_url",
+              "url",
+              "name",
+              "path",
+              "mime",
+              "is_directory",
+              "size",
+              "modified_date",
+            },
+            where.toString(),
+            args.toArray(new String[0]),
+            null,
+            null,
+            null
+          );
+      while (cursor.moveToNext()) {
+        FileEntry entry = fileEntryFromCursor(cursor);
+        if (seen.add(entry.url)) result.put(entry.toJSON());
+      }
+    } finally {
+      if (cursor != null) cursor.close();
+    }
+    return result;
+  }
+
+  private FileEntry fileEntryFromCursor(Cursor cursor) {
+    return new FileEntry(
+      cursor.getString(0),
+      cursor.getString(1),
+      cursor.getString(2),
+      cursor.getString(3),
+      cursor.getString(4),
+      cursor.isNull(5) ? null : cursor.getString(5),
+      cursor.getInt(6) != 0,
+      safeLong(cursor, 7),
+      safeLong(cursor, 8)
+    );
+  }
+
+  private void appendRootsClause(
+    StringBuilder where,
+    List<String> args,
+    JSONArray roots
+  ) {
+    if (roots == null || roots.length() == 0) return;
+    where.append(" AND root_url IN (");
+    boolean added = false;
+    for (int i = 0; i < roots.length(); i++) {
+      String root = roots.optString(i, "");
+      if (root.length() == 0) continue;
+      if (added) where.append(',');
+      where.append('?');
+      args.add(root);
+      added = true;
+    }
+    if (!added) {
+      where.append("NULL");
+    }
+    where.append(')');
+  }
+
+  private String escapeLike(String value) {
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+  }
+
+  private boolean shouldSkipDirectory(
+    String rootUrl,
+    String url,
+    String path,
+    JSONArray excludes
+  ) {
+    if (isExcluded(path, excludes) || isExcluded(path + "/", excludes)) {
+      return true;
+    }
+
+    return (
+      rootUrl != null &&
+      rootUrl.startsWith("content://com.termux.documents/tree/") &&
+      url != null &&
+      url.matches(".*::/data/data/com\\.termux/files/home/storage(?:/)?$")
+    );
   }
 
   private boolean shouldSkipSearchFile(JSONObject file, JSONObject options) {
@@ -1389,7 +1617,7 @@ class WorkspaceIndex {
       );
       db.execSQL(
         "CREATE TABLE IF NOT EXISTS files (" +
-        "url TEXT PRIMARY KEY, " +
+        "url TEXT, " +
         "root_url TEXT, " +
         "parent_url TEXT, " +
         "path TEXT, " +
@@ -1399,7 +1627,8 @@ class WorkspaceIndex {
         "size INTEGER, " +
         "modified_date INTEGER, " +
         "indexed_at INTEGER, " +
-        "skipped_reason TEXT" +
+        "skipped_reason TEXT, " +
+        "PRIMARY KEY (root_url, url)" +
         ")"
       );
       db.execSQL(

--- a/src/plugins/sdcard/src/android/WorkspaceIndex.java
+++ b/src/plugins/sdcard/src/android/WorkspaceIndex.java
@@ -49,6 +49,8 @@ class WorkspaceIndex {
   private static final int EXPLICIT_INCLUDE_READ_LIMIT_BYTES = 128 * 1024 * 1024;
   private static final int SAMPLE_BYTES = 8192;
   private static final int MAX_MATCHES_PER_FILE = 5000;
+  private static final int SEARCH_RESULT_BATCH_SIZE = 12;
+  private static final int SEARCH_RESULT_BATCH_MATCHES = 600;
 
   private static final Set<String> BINARY_EXTENSIONS = new HashSet<>();
   private static final Set<String> TEXT_EXTENSIONS = new HashSet<>();
@@ -665,8 +667,11 @@ class WorkspaceIndex {
     if (overlays == null) overlays = new JSONObject();
     String defaultEncoding = options.optString("defaultEncoding", "UTF-8");
     boolean useIndex = options.optBoolean("useIndex", false);
+    boolean batchResults = options.optBoolean("batchResults", false);
 
     Pattern pattern = compileSearchPattern(search, searchOptions);
+    JSONArray searchResultBatch = new JSONArray();
+    int batchedMatches = 0;
     int total = files.length();
     int processed = 0;
     int lastProgress = -1;
@@ -699,11 +704,7 @@ class WorkspaceIndex {
             overlays,
             defaultEncoding,
             useIndex,
-            allowLargeFile,
-            callback,
-            job.id,
-            total,
-            processed
+            allowLargeFile
           );
       } catch (Exception error) {
         Log.d(TAG, "Skipping unreadable search file " + file.optString("url"), error);
@@ -712,7 +713,6 @@ class WorkspaceIndex {
       }
       if (content == null) {
         processed += 1;
-        sendProgress(callback, job.id, total == 0 ? 100 : (processed * 100) / total);
         continue;
       }
 
@@ -724,14 +724,32 @@ class WorkspaceIndex {
         result.put("text", text);
         send(callback, result, true);
       } else {
-        JSONObject result = searchInContent(job.id, file, content, pattern);
-        if (result != null) send(callback, result, true);
+        JSONObject result = searchInContent(file, content, pattern);
+        if (result != null) {
+          if (batchResults) {
+            searchResultBatch.put(result);
+            batchedMatches += result.getJSONArray("matches").length();
+            if (
+              searchResultBatch.length() >= SEARCH_RESULT_BATCH_SIZE ||
+              batchedMatches >= SEARCH_RESULT_BATCH_MATCHES
+            ) {
+              flushSearchResultBatch(callback, job.id, searchResultBatch);
+              batchedMatches = 0;
+            }
+          } else {
+            JSONObject event = baseEvent(job.id, "search-result");
+            event.put("data", result);
+            send(callback, event, true);
+          }
+        }
       }
 
       processed += 1;
-      sendProgress(callback, job.id, total == 0 ? 100 : (processed * 100) / total);
     }
 
+    if (batchResults) {
+      flushSearchResultBatch(callback, job.id, searchResultBatch);
+    }
     sendProgress(callback, job.id, 100);
     send(callback, baseEvent(job.id, "replace".equals(mode) ? "done-replacing" : "done-searching"), false);
   }
@@ -751,7 +769,6 @@ class WorkspaceIndex {
   }
 
   private JSONObject searchInContent(
-    String id,
     JSONObject file,
     String content,
     Pattern pattern
@@ -817,10 +834,19 @@ class WorkspaceIndex {
     }
     data.put("limited", limited);
     data.put("text", text.toString());
+    return data;
+  }
 
-    JSONObject event = baseEvent(id, "search-result");
-    event.put("data", data);
-    return event;
+  private void flushSearchResultBatch(
+    CallbackContext callback,
+    String id,
+    JSONArray batch
+  ) throws JSONException {
+    if (batch.length() == 0) return;
+    JSONObject event = baseEvent(id, "search-results");
+    event.put("data", new JSONArray(batch.toString()));
+    send(callback, event, true);
+    while (batch.length() > 0) batch.remove(0);
   }
 
   private String getFileContent(
@@ -828,11 +854,7 @@ class WorkspaceIndex {
     JSONObject overlays,
     String defaultEncoding,
     boolean useIndex,
-    boolean allowLargeFile,
-    CallbackContext callback,
-    String jobId,
-    int totalFiles,
-    int processedFiles
+    boolean allowLargeFile
   ) throws Exception {
     String url = file.optString("url");
     if (overlays.has(url)) return overlays.optString(url, "");
@@ -875,11 +897,7 @@ class WorkspaceIndex {
       entry,
       defaultEncoding,
       allowLargeFile ? EXPLICIT_INCLUDE_READ_LIMIT_BYTES : DIRECT_SEARCH_READ_LIMIT_BYTES,
-      allowLargeFile ? EXPLICIT_INCLUDE_READ_LIMIT_BYTES : DIRECT_SEARCH_READ_LIMIT_BYTES,
-      callback,
-      jobId,
-      totalFiles,
-      processedFiles
+      allowLargeFile ? EXPLICIT_INCLUDE_READ_LIMIT_BYTES : DIRECT_SEARCH_READ_LIMIT_BYTES
     );
   }
 
@@ -893,11 +911,7 @@ class WorkspaceIndex {
         entry,
         defaultEncoding,
         INDEX_READ_LIMIT_BYTES,
-        MAX_INDEXED_CHARS,
-        null,
-        null,
-        0,
-        0
+        MAX_INDEXED_CHARS
       );
       if (text == null) return null;
       String encoding = normalizeEncoding(defaultEncoding);
@@ -922,26 +936,14 @@ class WorkspaceIndex {
     FileEntry entry,
     String defaultEncoding,
     int readLimitBytes,
-    int maxChars,
-    CallbackContext callback,
-    String jobId,
-    int totalFiles,
-    int processedFiles
+    int maxChars
   )
     throws Exception {
     if (entry.isDirectory || isBinary(entry) || entry.size > readLimitBytes) {
       return null;
     }
 
-    byte[] bytes = readBytes(
-      entry.url,
-      readLimitBytes + 1,
-      callback,
-      jobId,
-      totalFiles,
-      processedFiles,
-      entry.size
-    );
+    byte[] bytes = readBytes(entry.url, readLimitBytes + 1);
     if (bytes.length > readLimitBytes) return null;
     String encoding = detectEncoding(bytes, defaultEncoding);
     if (isSingleByteEncoding(encoding) && looksBinary(bytes)) return null;
@@ -950,15 +952,7 @@ class WorkspaceIndex {
     return text;
   }
 
-  private byte[] readBytes(
-    String url,
-    int limit,
-    CallbackContext callback,
-    String jobId,
-    int totalFiles,
-    int processedFiles,
-    long fileSize
-  ) throws Exception {
+  private byte[] readBytes(String url, int limit) throws Exception {
     InputStream input = null;
     try {
       if (isSafUrl(url)) {
@@ -972,18 +966,8 @@ class WorkspaceIndex {
       byte[] buffer = new byte[8192];
       int read;
       int total = 0;
-      int lastProgress = -1;
       while ((read = input.read(buffer)) != -1) {
         total += read;
-        if (callback != null && jobId != null && totalFiles > 0) {
-          long denominator = fileSize > 0 ? fileSize : limit;
-          int fileProgress = (int) Math.min(99, (total * 100L) / denominator);
-          int progress = ((processedFiles * 100) + fileProgress) / totalFiles;
-          if (progress != lastProgress) {
-            sendProgress(callback, jobId, progress);
-            lastProgress = progress;
-          }
-        }
         if (total > limit) {
           output.write(buffer, 0, read - (total - limit));
           break;

--- a/src/plugins/sdcard/src/android/WorkspaceIndex.java
+++ b/src/plugins/sdcard/src/android/WorkspaceIndex.java
@@ -7,6 +7,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.net.Uri;
+import android.os.CancellationSignal;
 import android.provider.DocumentsContract;
 import android.provider.DocumentsContract.Document;
 import android.util.Log;
@@ -200,6 +201,7 @@ class WorkspaceIndex {
 
   private final Context context;
   private final ContentResolver resolver;
+  private final ExecutorService indexExecutor = Executors.newSingleThreadExecutor();
   private final ExecutorService executor = Executors.newFixedThreadPool(2);
   private final Map<String, Job> jobs = new ConcurrentHashMap<>();
   private final DB db;
@@ -215,7 +217,7 @@ class WorkspaceIndex {
     final Job job = new Job(id);
     jobs.put(id, job);
 
-    executor.execute(
+    indexExecutor.execute(
       () -> {
         try {
           runScan(job, options, callback);
@@ -223,6 +225,18 @@ class WorkspaceIndex {
           sendError(callback, id, error);
         } finally {
           jobs.remove(id);
+        }
+      }
+    );
+  }
+
+  void update(JSONObject options, CallbackContext callback) {
+    indexExecutor.execute(
+      () -> {
+        try {
+          callback.success(runUpdate(options));
+        } catch (Exception error) {
+          callback.error(error.getMessage() == null ? error.toString() : error.getMessage());
         }
       }
     );
@@ -260,7 +274,7 @@ class WorkspaceIndex {
 
   void cancel(String id) {
     Job job = jobs.get(id);
-    if (job != null) job.cancelled = true;
+    if (job != null) job.cancel();
   }
 
   void markDirty(JSONArray urls) {
@@ -292,6 +306,11 @@ class WorkspaceIndex {
 
   private void runScan(Job job, JSONObject options, CallbackContext callback)
     throws Exception {
+    if (job.cancelled) {
+      send(callback, baseEvent(job.id, "cancelled"), false);
+      return;
+    }
+
     String rootUrl = options.getString("rootUrl");
     String title = options.optString("title", basename(rootUrl));
     JSONArray exclude = options.optJSONArray("excludeFolders");
@@ -370,6 +389,278 @@ class WorkspaceIndex {
     done.put("dirs", stats.dirs);
     done.put("indexed", stats.indexed);
     send(callback, done, false);
+  }
+
+  private JSONObject runUpdate(JSONObject options) throws Exception {
+    String rootUrl = options.getString("rootUrl");
+    String title = options.optString("title", getWorkspaceTitle(rootUrl));
+    JSONArray removed = options.optJSONArray("removed");
+    JSONArray added = options.optJSONArray("added");
+    JSONArray exclude = options.optJSONArray("excludeFolders");
+    boolean showHiddenFiles = options.optBoolean("showHiddenFiles", false);
+    String defaultEncoding = options.optString("defaultEncoding", "UTF-8");
+    SQLiteDatabase writable = db.getWritableDatabase();
+    int removedCount = 0;
+    int addedCount = 0;
+
+    writable.beginTransaction();
+    try {
+      if (removed != null) {
+        for (int i = 0; i < removed.length(); i++) {
+          String url = removed.optString(i, "");
+          if (url.length() == 0 || rootUrl.equals(url)) continue;
+          removedCount += deleteIndexedSubtree(writable, rootUrl, url);
+        }
+      }
+
+      if (added != null) {
+        for (int i = 0; i < added.length(); i++) {
+          JSONObject change = added.optJSONObject(i);
+          if (change == null) continue;
+          String url = change.optString("url", "");
+          String parentUrl = change.optString("parentUrl", "");
+          if (url.length() == 0 || parentUrl.length() == 0) continue;
+
+          removedCount += deleteIndexedSubtree(writable, rootUrl, url);
+          FileEntry entry = readEntry(rootUrl, parentUrl, url, title);
+          if (entry == null) continue;
+          if (!showHiddenFiles && entry.name.startsWith(".")) continue;
+
+          saveFile(entry);
+          addedCount += 1;
+          if (
+            entry.isDirectory &&
+            !shouldSkipDirectory(rootUrl, entry.url, entry.path, exclude)
+          ) {
+            Job job = new Job("update-" + UUID.randomUUID());
+            ScanStats stats = new ScanStats();
+            if (isSafUrl(url)) {
+              SafUrl rootSafUrl = parseSafUrl(rootUrl);
+              scanSafDir(
+                job,
+                null,
+                rootSafUrl.treeUrl,
+                rootUrl,
+                parseSafUrl(url).docId,
+                url,
+                entry.path,
+                title,
+                exclude,
+                showHiddenFiles,
+                defaultEncoding,
+                false,
+                false,
+                new JSONArray(),
+                stats
+              );
+            } else {
+              scanFileDir(
+                job,
+                null,
+                rootUrl,
+                fileFromUrl(url),
+                url,
+                entry.path,
+                title,
+                exclude,
+                showHiddenFiles,
+                defaultEncoding,
+                false,
+                false,
+                new JSONArray(),
+                stats
+              );
+            }
+            addedCount += stats.files + stats.dirs;
+          }
+        }
+      }
+
+      ContentValues workspace = new ContentValues();
+      workspace.put("root_url", rootUrl);
+      workspace.put("title", title);
+      workspace.put("indexed_at", System.currentTimeMillis());
+      int updated = writable.update(
+        "workspaces",
+        workspace,
+        "root_url = ?",
+        new String[] { rootUrl }
+      );
+      if (updated == 0) writable.insert("workspaces", null, workspace);
+      writable.setTransactionSuccessful();
+    } finally {
+      writable.endTransaction();
+    }
+
+    JSONObject result = new JSONObject();
+    result.put("added", addedCount);
+    result.put("removed", removedCount);
+    return result;
+  }
+
+  private FileEntry readEntry(
+    String rootUrl,
+    String parentUrl,
+    String url,
+    String title
+  ) {
+    String parentPath = getIndexedPath(rootUrl, parentUrl, title);
+    if (isSafUrl(url)) {
+      Cursor cursor = null;
+      try {
+        cursor =
+          resolver.query(
+            formatSafUri(url),
+            new String[] {
+              Document.COLUMN_DISPLAY_NAME,
+              Document.COLUMN_MIME_TYPE,
+              Document.COLUMN_SIZE,
+              Document.COLUMN_LAST_MODIFIED,
+            },
+            null,
+            null,
+            null
+          );
+        if (cursor == null || !cursor.moveToFirst()) return null;
+        String name = cursor.getString(0);
+        String mime = normalizeMime(name, cursor.getString(1));
+        boolean isDirectory = Document.MIME_TYPE_DIR.equals(mime);
+        return new FileEntry(
+          rootUrl,
+          parentUrl,
+          url,
+          name,
+          joinPath(parentPath, name),
+          mime,
+          isDirectory,
+          safeLong(cursor, 2),
+          safeLong(cursor, 3)
+        );
+      } catch (Exception error) {
+        Log.d(TAG, "Unable to refresh SAF index entry " + url, error);
+        return null;
+      } finally {
+        if (cursor != null) cursor.close();
+      }
+    }
+
+    File file = fileFromUrl(url);
+    if (!file.exists()) return null;
+    String name = file.getName();
+    boolean isDirectory = file.isDirectory();
+    return new FileEntry(
+      rootUrl,
+      parentUrl,
+      url,
+      name,
+      joinPath(parentPath, name),
+      isDirectory
+        ? Document.MIME_TYPE_DIR
+        : normalizeMime(name, guessMime(name)),
+      isDirectory,
+      file.length(),
+      file.lastModified()
+    );
+  }
+
+  private String getIndexedPath(
+    String rootUrl,
+    String url,
+    String fallbackTitle
+  ) {
+    if (rootUrl.equals(url)) return fallbackTitle;
+    Cursor cursor = null;
+    try {
+      cursor =
+        db
+          .getReadableDatabase()
+          .query(
+            "files",
+            new String[] { "path" },
+            "root_url = ? AND url = ?",
+            new String[] { rootUrl, url },
+            null,
+            null,
+            null,
+            "1"
+          );
+      if (cursor.moveToFirst()) return cursor.getString(0);
+    } finally {
+      if (cursor != null) cursor.close();
+    }
+    return fallbackTitle;
+  }
+
+  private String getWorkspaceTitle(String rootUrl) {
+    Cursor cursor = null;
+    try {
+      cursor =
+        db
+          .getReadableDatabase()
+          .query(
+            "workspaces",
+            new String[] { "title" },
+            "root_url = ?",
+            new String[] { rootUrl },
+            null,
+            null,
+            null,
+            "1"
+          );
+      if (cursor.moveToFirst()) return cursor.getString(0);
+    } finally {
+      if (cursor != null) cursor.close();
+    }
+    return basename(rootUrl);
+  }
+
+  private int deleteIndexedSubtree(
+    SQLiteDatabase writable,
+    String rootUrl,
+    String url
+  ) {
+    ArrayDeque<String> directories = new ArrayDeque<>();
+    Set<String> visitedDirectories = new HashSet<>();
+    Set<String> urls = new HashSet<>();
+    directories.add(url);
+    urls.add(url);
+
+    while (!directories.isEmpty()) {
+      String parentUrl = directories.removeFirst();
+      if (!visitedDirectories.add(parentUrl)) continue;
+      Cursor cursor = null;
+      try {
+        cursor =
+          writable.query(
+            "files",
+            new String[] { "url", "is_directory" },
+            "root_url = ? AND parent_url = ?",
+            new String[] { rootUrl, parentUrl },
+            null,
+            null,
+            null
+          );
+        while (cursor.moveToNext()) {
+          String childUrl = cursor.getString(0);
+          urls.add(childUrl);
+          if (cursor.getInt(1) != 0) directories.add(childUrl);
+        }
+      } finally {
+        if (cursor != null) cursor.close();
+      }
+    }
+
+    int deleted = 0;
+    for (String entryUrl : urls) {
+      writable.delete("content", "url = ?", new String[] { entryUrl });
+      deleted +=
+        writable.delete(
+          "files",
+          "root_url = ? AND url = ?",
+          new String[] { rootUrl, entryUrl }
+        );
+    }
+    return deleted;
   }
 
   private void scanFileDir(
@@ -474,6 +765,8 @@ class WorkspaceIndex {
       parentDocId
     );
     Cursor cursor = null;
+    CancellationSignal signal = new CancellationSignal();
+    CancellationSignal previousSignal = job.setSignal(signal);
     try {
       try {
         cursor =
@@ -488,7 +781,8 @@ class WorkspaceIndex {
             },
             null,
             null,
-            null
+            null,
+            signal
           );
       } catch (Exception error) {
         Log.d(TAG, "Skipping unreadable SAF directory " + parentUrl, error);
@@ -556,6 +850,7 @@ class WorkspaceIndex {
       Log.d(TAG, "Stopping unreadable SAF directory " + parentUrl, error);
     } finally {
       if (cursor != null) cursor.close();
+      job.restoreSignal(signal, previousSignal);
     }
   }
 
@@ -1465,9 +1760,32 @@ class WorkspaceIndex {
   private static class Job {
     final String id;
     volatile boolean cancelled = false;
+    volatile CancellationSignal signal;
 
     Job(String id) {
       this.id = id;
+    }
+
+    void cancel() {
+      cancelled = true;
+      CancellationSignal activeSignal = signal;
+      if (activeSignal != null) activeSignal.cancel();
+    }
+
+    CancellationSignal setSignal(CancellationSignal nextSignal) {
+      CancellationSignal previousSignal = signal;
+      signal = nextSignal;
+      if (cancelled) nextSignal.cancel();
+      return previousSignal;
+    }
+
+    void restoreSignal(
+      CancellationSignal currentSignal,
+      CancellationSignal previousSignal
+    ) {
+      if (signal != currentSignal) return;
+      signal = previousSignal;
+      if (cancelled && previousSignal != null) previousSignal.cancel();
     }
   }
 

--- a/src/plugins/sdcard/www/plugin.js
+++ b/src/plugins/sdcard/www/plugin.js
@@ -75,6 +75,9 @@ module.exports = {
   workspaceSearch: function (options, onEvent, onFail) {
     cordova.exec(onEvent, onFail, 'SDcard', 'workspace search', [options || {}]);
   },
+  workspaceQuery: function (options, onSuccess, onFail) {
+    cordova.exec(onSuccess, onFail, 'SDcard', 'workspace query', [options || {}]);
+  },
   workspaceCancel: function (id, onSuccess, onFail) {
     cordova.exec(onSuccess, onFail, 'SDcard', 'workspace cancel', [id]);
   },

--- a/src/plugins/sdcard/www/plugin.js
+++ b/src/plugins/sdcard/www/plugin.js
@@ -72,6 +72,9 @@ module.exports = {
   workspaceScan: function (options, onEvent, onFail) {
     cordova.exec(onEvent, onFail, 'SDcard', 'workspace scan', [options || {}]);
   },
+  workspaceUpdate: function (options, onSuccess, onFail) {
+    cordova.exec(onSuccess, onFail, 'SDcard', 'workspace update', [options || {}]);
+  },
   workspaceSearch: function (options, onEvent, onFail) {
     cordova.exec(onEvent, onFail, 'SDcard', 'workspace search', [options || {}]);
   },

--- a/src/sidebarApps/searchInFiles/index.js
+++ b/src/sidebarApps/searchInFiles/index.js
@@ -118,6 +118,10 @@ let searching = false;
 let searchVersion = 0;
 let pendingResultText = "";
 let pendingResultFlush = 0;
+let nativeResultQueue = [];
+let nativeResultCursor = 0;
+let nativeResultFrame = 0;
+let pendingNativeSearchFinishVersion = null;
 let nativeSearchId = null;
 let activeSearchTasks = 0;
 let activeReplaceTasks = 0;
@@ -435,6 +439,61 @@ function appendSearchResult(data) {
 	}
 }
 
+function enqueueNativeSearchResults(batch, version) {
+	if (!Array.isArray(batch) || version !== searchVersion) return;
+	nativeResultQueue.push(...batch);
+	scheduleNativeResultDrain(version);
+}
+
+function scheduleNativeResultDrain(version) {
+	if (nativeResultFrame) return;
+	const schedule =
+		window.requestAnimationFrame || ((callback) => setTimeout(callback, 16));
+	nativeResultFrame = schedule(() => drainNativeSearchResults(version));
+}
+
+function drainNativeSearchResults(version) {
+	nativeResultFrame = 0;
+	if (version !== searchVersion) {
+		clearNativeResultQueue();
+		return;
+	}
+
+	const start = performance.now();
+	let processed = 0;
+	while (
+		nativeResultCursor < nativeResultQueue.length &&
+		processed < 4 &&
+		performance.now() - start < 8
+	) {
+		appendSearchResult(nativeResultQueue[nativeResultCursor++]);
+		processed += 1;
+	}
+
+	if (nativeResultCursor < nativeResultQueue.length) {
+		scheduleNativeResultDrain(version);
+		return;
+	}
+
+	nativeResultQueue = [];
+	nativeResultCursor = 0;
+	if (pendingNativeSearchFinishVersion === version) {
+		pendingNativeSearchFinishVersion = null;
+		void finishSearchTask(version);
+	}
+}
+
+function clearNativeResultQueue() {
+	if (nativeResultFrame) {
+		const cancel = window.cancelAnimationFrame || clearTimeout;
+		cancel(nativeResultFrame);
+	}
+	nativeResultFrame = 0;
+	nativeResultQueue = [];
+	nativeResultCursor = 0;
+	pendingNativeSearchFinishVersion = null;
+}
+
 function groupMatchesForDisplay(matches) {
 	const rows = [];
 	const seen = new Set();
@@ -547,6 +606,7 @@ function onInput(e) {
 	resultOverview.reset();
 	resetResultScroll();
 	clearPendingResultText();
+	clearNativeResultQueue();
 	searchResult.setValue("");
 	removeEvents();
 	if (!$search.value) {
@@ -686,6 +746,7 @@ function sendNativeSearch(
 			overlays: getOpenFileOverlays(),
 			defaultEncoding: settings.value.defaultFileEncoding,
 			useIndex: store.useIndex,
+			batchResults: true,
 		},
 		async (event) => {
 			if (
@@ -705,6 +766,9 @@ function sendNativeSearch(
 				case "search-result":
 					appendSearchResult(event.data);
 					break;
+				case "search-results":
+					enqueueNativeSearchResults(event.data, version);
+					break;
 				case "replace-result":
 					filesReplaced.push(event.file);
 					openFile(event.file.url, {
@@ -714,7 +778,14 @@ function sendNativeSearch(
 					break;
 				case "done-searching":
 					nativeSearchId = null;
-					await finishSearchTask(version);
+					if (
+						nativeResultCursor < nativeResultQueue.length ||
+						nativeResultFrame
+					) {
+						pendingNativeSearchFinishVersion = version;
+					} else {
+						await finishSearchTask(version);
+					}
 					break;
 				case "done-replacing":
 					nativeSearchId = null;
@@ -724,6 +795,7 @@ function sendNativeSearch(
 					console.error(event.error);
 					$error.value = event.error || "Native search failed";
 					nativeSearchId = null;
+					clearNativeResultQueue();
 					await (mode === "replace"
 						? finishReplaceTask(version)
 						: finishSearchTask(version));
@@ -735,6 +807,7 @@ function sendNativeSearch(
 			console.error(error);
 			$error.value = error?.message || String(error);
 			nativeSearchId = null;
+			clearNativeResultQueue();
 			await (mode === "replace"
 				? finishReplaceTask(version)
 				: finishSearchTask(version));

--- a/src/sidebarApps/searchInFiles/index.js
+++ b/src/sidebarApps/searchInFiles/index.js
@@ -8,8 +8,10 @@ import Sidebar, { preventSlide } from "components/sidebar";
 import escapeStringRegexp from "escape-string-regexp";
 import Reactive from "html-tag-js/reactive";
 import Ref from "html-tag-js/ref";
+import fileIndex from "lib/fileIndex";
 import files, { Tree, whenReady as waitForFileList } from "lib/fileList";
 import openFile from "lib/openFile";
+import { addedFolder } from "lib/openFolder";
 import settings from "lib/settings";
 import helpers from "utils/helpers";
 import { createSearchResultView } from "./cmResultView";
@@ -576,10 +578,17 @@ async function searchAll() {
 	if (version !== searchVersion) return;
 
 	const allFiles = files().filter((file) => !helpers.isBinary(file));
-	const forceUrls = new Set();
+	const nativeRoots = addedFolder
+		.filter(({ listFiles }) => listFiles)
+		.map(({ url }) => url)
+		.filter((url) => supportsNativeSearch(url));
+	const nativeOpenFiles = [];
 	editorManager.files.forEach((file) => {
 		if (!file.uri || helpers.isBinary(file.uri)) return;
-		forceUrls.add(file.uri);
+		if (supportsNativeSearch(file.uri)) {
+			nativeOpenFiles.push(new Tree(file.name, file.uri, false));
+			return;
+		}
 		const exists = allFiles.find((f) => f.url === file.uri);
 		if (exists) return;
 
@@ -588,7 +597,7 @@ async function searchAll() {
 
 	const filesToSearch = allFiles;
 
-	if (!filesToSearch.length) {
+	if (!filesToSearch.length && !nativeRoots.length && !nativeOpenFiles.length) {
 		searchResult.setGhostText(strings["no result"], { row: 0, column: 0 });
 		$progress.value = 100;
 		return;
@@ -599,16 +608,20 @@ async function searchAll() {
 	fileNames.length = 0;
 	currentSearchRegex = regex;
 	searchResult.setGhostText(strings["searching..."], { row: 0, column: 0 });
-	const nativeFiles = filesToSearch.filter((file) =>
-		supportsNativeSearch(file.url),
-	);
 	const workerFiles = filesToSearch.filter(
 		(file) => !supportsNativeSearch(file.url),
 	);
 	activeSearchTasks = 0;
-	if (nativeFiles.length) {
+	if (nativeRoots.length || nativeOpenFiles.length) {
 		activeSearchTasks += 1;
-		sendNativeSearch("search", nativeFiles, search, options);
+		sendNativeSearch(
+			"search",
+			nativeOpenFiles,
+			search,
+			options,
+			undefined,
+			nativeRoots,
+		);
 	}
 	if (workerFiles.length) {
 		activeSearchTasks += 1;
@@ -633,6 +646,7 @@ async function readSearchFileContent(uri) {
 
 function supportsNativeSearch(url = "") {
 	return (
+		fileIndex.supports(url) &&
 		typeof sdcard !== "undefined" &&
 		typeof sdcard.workspaceSearch === "function" &&
 		(/^file:/.test(url) || /^content:/.test(url))
@@ -649,7 +663,14 @@ function cancelNativeSearch() {
 	nativeSearchId = null;
 }
 
-function sendNativeSearch(mode, searchFiles, search, options, replace) {
+function sendNativeSearch(
+	mode,
+	searchFiles,
+	search,
+	options,
+	replace,
+	roots = [],
+) {
 	const id = `search-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const version = searchVersion;
 	nativeSearchId = id;
@@ -658,10 +679,11 @@ function sendNativeSearch(mode, searchFiles, search, options, replace) {
 			id,
 			mode,
 			files: searchFiles.map((file) => file.toJSON()),
+			roots,
 			search,
 			replace,
 			options,
-			overlays: getOpenFileOverlays(searchFiles),
+			overlays: getOpenFileOverlays(),
 			defaultEncoding: settings.value.defaultFileEncoding,
 			useIndex: store.useIndex,
 		},
@@ -720,11 +742,10 @@ function sendNativeSearch(mode, searchFiles, search, options, replace) {
 	);
 }
 
-function getOpenFileOverlays(searchFiles) {
-	const supportedUrls = new Set(searchFiles.map(({ url }) => url));
+function getOpenFileOverlays() {
 	const overlays = {};
 	editorManager.files.forEach((file) => {
-		if (!file.uri || !supportedUrls.has(file.uri)) return;
+		if (!file.uri || !supportsNativeSearch(file.uri)) return;
 		if (!file.session?.doc) return;
 		try {
 			overlays[file.uri] = getDocText(file.session.doc);
@@ -743,16 +764,7 @@ async function waitForFileListIfReady() {
 }
 
 function markIndexDirty(urls) {
-	if (
-		typeof sdcard !== "undefined" &&
-		typeof sdcard.workspaceMarkDirty === "function"
-	) {
-		try {
-			sdcard.workspaceMarkDirty(urls);
-		} catch (_) {
-			// ignore native dirty-mark failures
-		}
-	}
+	fileIndex.markDirty(urls).catch(() => {});
 }
 
 function appendSearchResultText(text) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -474,6 +474,7 @@ export default {
 			};
 		};
 		let firstCreatedPath = null;
+		let firstCreatedParentUri = null;
 		let firstCreatedType = null;
 		let firstTargetUri = uri;
 
@@ -498,6 +499,7 @@ export default {
 
 			if (entry.created && firstCreatedPath === null) {
 				firstCreatedPath = entry.url;
+				firstCreatedParentUri = currentUri;
 				firstCreatedType = expectedType;
 			}
 
@@ -506,6 +508,7 @@ export default {
 
 		return {
 			uri: firstCreatedPath || firstTargetUri,
+			parentUri: firstCreatedParentUri || uri,
 			created: Boolean(firstCreatedPath),
 			type:
 				firstCreatedType || (isFile && parts.length === 1 ? "file" : "folder"),


### PR DESCRIPTION
## Summary

Moves file indexing and project-wide search for SAF and `file://` workspaces to the Android native layer.

This prevents large workspaces, such as Termux home, from creating a complete file tree in the WebView.

## Changes

- Added a native SQLite workspace index.
- Added paginated native filename queries.
- Added the new asynchronous `fileIndex` plugin API.
- Migrated Quick Open to native queries.
- Migrated project-wide search to native root-based search.
- Batched native search results to reduce Cordova bridge callbacks.
- Removed progress callbacks from individual file reads.
- Skips files and directories that return permission errors.
- Fixed project search after closing one folder and opening another.
- Fixed folder exclusion matching, including `node_modules`.
- Prevented recursive indexing of Termux `~/storage`.
- Kept FTP, SFTP, and custom storage providers on the JavaScript fallback.

## Breaking changes

`acode.require("fileList")` is deprecated.

It now contains files from non-native providers only. Plugins using it for SAF or `file://` workspaces must migrate to:

```js
const fileIndex = acode.require("fileIndex");
const result = await fileIndex.query({
  roots: [workspaceUrl],
  text: "filename",
  limit: 200,
});
```

Differences from `fileList`:

- `fileIndex` is asynchronous.
- Results are flat metadata records instead of `Tree` objects.
- Large results use cursor pagination.
- Native search can emit batched `search-results` events.

The native index database version is also updated. Existing generated indexes will be rebuilt automatically.

## Compatibility

- SAF and `file://`: native index and search.
- FTP and SFTP: existing JavaScript fallback.
- Low-level `sdcard.workspaceSearch()` keeps single-result events unless `batchResults: true` is provided.
