### PR TITLE
fix(fileBrowser): exclude non-selectable system utility tiles from batch selection operations

### DIFF
--- a/src/pages/fileBrowser/fileBrowser.js
+++ b/src/pages/fileBrowser/fileBrowser.js
@@ -860,6 +860,7 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 				$list
 					.querySelectorAll(".tile:not(.selection-header)")
 					.forEach((item) => {
+						if (item.dataset.notSelectable != null) return;
 						const checkbox = Checkbox("", false);
 						checkbox.onclick = () => {
 							const url = item.querySelector("data-url").textContent;
@@ -912,12 +913,12 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 			const $el = e.target;
 
 			if (isSelectionMode) {
-				const checkbox = $el.closest(".tile")?.querySelector(".input-checkbox");
+				const $el2 = $el.closest(".tile");
+				if ($el2?.dataset.notSelectable != null) return;
+				const checkbox = $el2?.querySelector(".input-checkbox");
 				if (checkbox && !$el.closest(".selection-header")) {
 					checkbox.checked = !checkbox.checked;
-					const url = $el
-						.closest(".tile")
-						.querySelector("data-url").textContent;
+					const url = $el2.querySelector("data-url").textContent;
 					if (checkbox.checked) {
 						selectedItems.add(url);
 					} else {
@@ -1394,12 +1395,14 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 				util.pushFolder(allStorages, strings["add a storage"], "", {
 					storageType: "notification",
 					uuid: "addstorage",
+					notSelectable: true,
 				});
 			}
 
 			if (IS_FILE_MODE) {
 				util.pushFolder(allStorages, "Select document", null, {
 					"open-doc": true,
+					notSelectable: true,
 				});
 			}
 

--- a/src/pages/fileBrowser/list.hbs
+++ b/src/pages/fileBrowser/list.hbs
@@ -7,6 +7,7 @@
     type="{{type}}"
     name="{{name}}"
     {{#home}}home="{{.}}"{{/home}}
+    {{#notSelectable}}data-not-selectable{{/notSelectable}}
     {{#open-doc}}open-doc="true"{{/open-doc}}
     {{#ftp-account}}ftp-account{{/ftp-account}}
     {{#disabled}}disabled{{/disabled}}


### PR DESCRIPTION
### 📌 Summary
This pull request introduces explicit safeguards across the file browser template and interaction handlers to isolate non-selectable system utility tiles (e.g., "Add a storage" prompts and "Select document" system actions) from batch selection modes and multi-item operations. 

---

### 🔎 Problem & Context
In the file browser component, system utility notifications and action triggers reside in the exact same DOM list container (`.tile:not(.selection-header)`) alongside standard user files and directories. Previously, enabling selection mode or performing batch actions (such as toggling all checkboxes or clicking across items) would inadvertently select these utility items.

Because these utility tiles lack valid file path URLs or context data expected by batch action handlers, including them in the selection pool resulted in runtime exceptions and unexpected behaviors during batch operations (e.g., bulk moving, deleting, or archive operations).

---

### 🛠️ Key Changes

1. **Handlebar Template Update (`src/pages/fileBrowser/list.hbs`)**:
   - Extended the list item template contract to render a `data-not-selectable` HTML dataset attribute whenever the item context defines `{{#notSelectable}}`.

2. **System Utility Tile Configuration (`src/pages/fileBrowser/fileBrowser.js`)**:
   - Updated the metadata payload for system utility tiles—specifically the "Add a storage" action (`strings["add a storage"]`) and the "Select document" document picker action—to pass `notSelectable: true` during initialization.

3. **Selection Handler Guards (`src/pages/fileBrowser/fileBrowser.js`)**:
   - **Selection Mode Initialization**: Updated list item iterations during selection mode activation to check for `item.dataset.notSelectable != null` and bypass checkbox creation/injection for utility tiles.
   - **Touch & Click Delegation**: Guarded click handlers in selection mode by evaluating `$el2?.dataset.notSelectable != null` and returning early. This prevents utility item state toggling, checkbox interaction, and invalid URL accumulation within the `selectedItems` tracking set.

---

### 🧪 Verification & Testing Steps
1. Open the File Browser view.
2. Enter **Selection Mode**.
3. Verify that the "Add a storage" and "Select document" tiles do not display active selection checkboxes and cannot be toggled.
4. Select all items in the list and perform batch actions (delete, copy); verify that no runtime errors occur and utility tiles remain unselected.

---

### 📂 File Changes Breakdown
- **`src/pages/fileBrowser/fileBrowser.js`**: Added guards checking `dataset.notSelectable` in selection initialization and click handlers, and flagged utility folders with `notSelectable: true`.
- **`src/pages/fileBrowser/list.hbs`**: Added the conditional `{{#notSelectable}}data-not-selectable{{/notSelectable}}` attribute definition to template rendered items.

<sub>(PR name and description are AI generated (Gemini 3.6 Flash))</sub>