### PR TITLE
feat(file-browser): integrate selection mode state with `actionStack` for back navigation

### DIFF
--- a/src/pages/fileBrowser/fileBrowser.js
+++ b/src/pages/fileBrowser/fileBrowser.js
@@ -882,7 +882,19 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 				if ($openFolder) {
 					$openFolder.disabled = true;
 				}
+
+				if (!actionStack.has("fbSelection")) {
+					actionStack.push({
+						id: "fbSelection",
+						action: () => {
+							isSelectionMode = false;
+							toggleSelectionMode(false);
+						},
+					});
+				}
 			} else {
+				actionStack.remove("fbSelection");
+
 				$list.classList.remove("selection-mode");
 				$list.querySelector(".selection-header")?.remove();
 				$list.querySelectorAll(".input-checkbox").forEach((cb) => cb.remove());


### PR DESCRIPTION
## Overview
Integrates the file browser's multi-item selection mode into the application-wide `actionStack`. This ensures that triggering a back navigation action (such as pressing a physical device back button, hardware key, or system gesture) while in selection mode cleanly exits selection mode before popping the current directory view or closing the page.

## Problem Context
Previously, entering selection mode within the file browser operated independently of the global `actionStack` context. Consequently:
- Initiating a back navigation action while items were actively selected would bypass the selection state overlay and immediately pop the directory or navigate away from the current workspace, resulting in lost user context.
- Exiting selection mode via non-back UI elements (e.g., confirmation buttons or manual dismissal) did not explicitly clean up lingering state handles, risking desynchronization between active UI layers and back-stack history.

## Detailed Code Changes
* **`src/pages/fileBrowser/fileBrowser.js`**:
  * **Stack Registration**: Guarded entry check using `!actionStack.has("fbSelection")` when enabling multi-selection mode. Pushes an action descriptor:
    ```javascript
    {
        id: "fbSelection",
        action: () => {
            isSelectionMode = false;
            toggleSelectionMode(false);
        }
    }
    ```
    This intercepts back action events to reset internal flags (`isSelectionMode = false`) and trigger full UI state reset via `toggleSelectionMode(false)`.
  * **Stack Cleanup**: Added `actionStack.remove("fbSelection")` to the exit/deactivation block (`else` branch) to unregister the selection frame from `actionStack` whenever selection mode is dismissed programmatically or via explicit user confirmation/cancellation.

## Architecture & System Impact
- **Navigation Safety**: Establishes a modal layer for selection mode inside `actionStack`, prioritizing selection exit over structural application navigation.
- **Stack Idempotency**: Prevents duplicate action registration via `actionStack.has("fbSelection")` conditional checks.
- **Lifecycle Cleanup**: Ensures clean stack teardown when selection mode terminates through standard user interactions.

## Verification Checklist
- [x] **Enter Selection Mode**: Verify `fbSelection` is present in `actionStack`.
- [x] **Back Gesture / Hardware Back**: Verify pressing back cancels selection mode while keeping the user inside the current folder directory.
- [x] **Manual Mode Dismissal**: Verify exiting selection mode via UI controls invokes `actionStack.remove("fbSelection")`, leaving no leftover frames in the stack.

<sub>(PR name and description are AI generated (Gemini 3.6 Flash))</sub>