### PR TITLE
refactor(file-browser): extract reusable deletion logic and abstract Termux URI validation

### DIFF
--- a/src/pages/fileBrowser/fileBrowser.js
+++ b/src/pages/fileBrowser/fileBrowser.js
@@ -603,43 +603,7 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 					);
 
 					try {
-						for (const url of selectedItems) {
-							if ((await fsOperation(url).stat()).isDirectory) {
-								if (url.startsWith("content://com.termux.documents/tree/")) {
-									const fs = fsOperation(url);
-									const entries = await fs.lsDir();
-									if (entries.length === 0) {
-										await fs.delete();
-									} else {
-										const deleteRecursively = async (currentUrl) => {
-											const currentFs = fsOperation(currentUrl);
-											const currentEntries = await currentFs.lsDir();
-											for (const entry of currentEntries) {
-												if (entry.isDirectory) {
-													await deleteRecursively(entry.url);
-												} else {
-													await fsOperation(entry.url).delete();
-												}
-											}
-											await currentFs.delete();
-										};
-										await deleteRecursively(url);
-									}
-								} else {
-									await fsOperation(url).delete();
-								}
-								helpers.updateUriOfAllActiveFiles(url);
-								recents.removeFolder(url);
-							} else {
-								const fs = fsOperation(url);
-								await fs.delete();
-								const openedFile = editorManager.getFile(url, "uri");
-								if (openedFile) openedFile.uri = null;
-							}
-							recents.removeFile(url);
-							openFolder.removeItem(url);
-							delete cachedDir[url];
-						}
+						for (const url of selectedItems) await deleteDirOrFile(url);
 						toast(strings.success);
 						reload();
 						isSelectionMode = false;
@@ -686,6 +650,50 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 			});
 			reject(err);
 			$page.hide();
+		}
+
+		/**
+		 * @param {string} url
+		 */
+		function isTermuxUrl(url) {
+			url = `${url ?? ""}`;
+			return url.startsWith("content://com.termux.documents/tree/");
+		}
+
+		/**
+		 * @param {string} url
+		 * @param {string} [type]
+		 */
+		async function deleteDirOrFile(url, type) {
+			const fs = fsOperation(url);
+			const isDir = type ? helpers.isDir(type) : (await fs.stat()).isDirectory;
+
+			if (isDir && isTermuxUrl(url)) {
+				const deleteRecursively = async (currentFs) => {
+					const entries = await currentFs.lsDir();
+					if (entries) {
+						for (const entry of entries) {
+							const fs = fsOperation(entry.url);
+							await (entry.isDirectory ? deleteRecursively(fs) : fs.delete());
+						}
+					}
+					await currentFs.delete();
+				};
+				await deleteRecursively(fs);
+			} else {
+				await fs.delete();
+			}
+
+			if (isDir) {
+				helpers.updateUriOfAllActiveFiles(url);
+				recents.removeFolder(url);
+			} else {
+				const openedFile = editorManager.getFile(url, "uri");
+				if (openedFile) openedFile.uri = null;
+			}
+			recents.removeFile(url);
+			openFolder.removeItem(url);
+			delete cachedDir[url];
 		}
 
 		function updateSelectionCount($count) {
@@ -1151,7 +1159,7 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 			}
 
 			async function renameFile(newname) {
-				if (url.startsWith("content://com.termux.documents/tree/")) {
+				if (isTermuxUrl(url)) {
 					if (helpers.isDir(type)) {
 						alert(strings.warning, strings["rename not supported"]);
 						return;
@@ -1203,42 +1211,8 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 
 			async function removeFile() {
 				try {
-					if (helpers.isDir(type)) {
-						if (url.startsWith("content://com.termux.documents/tree/")) {
-							const fs = fsOperation(url);
-							const entries = await fs.lsDir();
-							if (entries.length === 0) {
-								await fs.delete();
-							} else {
-								const deleteRecursively = async (currentUrl) => {
-									const currentFs = fsOperation(currentUrl);
-									const currentEntries = await currentFs.lsDir();
-									for (const entry of currentEntries) {
-										if (entry.isDirectory) {
-											await deleteRecursively(entry.url);
-										} else {
-											await fsOperation(entry.url).delete();
-										}
-									}
-									await currentFs.delete();
-								};
-								await deleteRecursively(url);
-							}
-						} else {
-							await fsOperation(url).delete();
-						}
-						helpers.updateUriOfAllActiveFiles(url);
-						recents.removeFolder(url);
-					} else {
-						const fs = fsOperation(url);
-						await fs.delete();
-						const openedFile = editorManager.getFile(url, "uri");
-						if (openedFile) openedFile.uri = null;
-					}
-					recents.removeFile(url);
-					openFolder.removeItem(url);
+					await deleteDirOrFile(url, type);
 					toast(strings.success);
-					delete cachedDir[url];
 					reload();
 				} catch (err) {
 					window.log("error", err);


### PR DESCRIPTION
This pull request refactors the file and folder deletion routines within `src/pages/fileBrowser/fileBrowser.js`. Previously, identical recursive deletion logic and post-deletion state cleanup were duplicated across both batch deletion (selection mode) and individual item removal (`removeFile`).

By consolidating these workflows into targeted helper functions (`deleteDirOrFile` and `isTermuxUrl`), this PR reduces code redundancy by ~26 lines, improves readability, and ensures consistent state maintenance across all deletion paths.

---

## 🛠️ Key Changes

### 1. Unified Deletion Logic (`deleteDirOrFile`)
* **Extracted Centralized Helper:** Created an `async function deleteDirOrFile(url, type)` helper that handles both single files and directories.
* **Consolidated State Cleanup:** Centralized side-effect cleanup routines directly into `deleteDirOrFile`:
  * Updating URIs of active editor tabs (`helpers.updateUriOfAllActiveFiles`).
  * Removing references from recents (`recents.removeFolder` / `recents.removeFile`).
  * Clearing items from open folder states (`openFolder.removeItem`).
  * Invalidating directory cache (`delete cachedDir[url]`).
* **Simplified Workflows:** Replaced duplicated multi-line blocks in both batch deletion (`for (const url of selectedItems) await deleteDirOrFile(url);`) and single-file deletion (`removeFile`).

### 2. Termux URI Validation Abstraction (`isTermuxUrl`)
* **Extracted Helper:** Created `isTermuxUrl(url)` to encapsulate string checking for the `content://com.termux.documents/tree/` provider.
* **Improved Safety:** Standardized string coercion (`${url ?? ""}`) to prevent runtime null/undefined evaluation errors.
* **Refactored Consumers:** Replaced direct `url.startsWith(...)` calls in rename handlers and recursive deletion steps with `isTermuxUrl()`.

### 3. Streamlined Recursive Termux Directory Traversal
* Refactored `deleteRecursively` to pass `fsOperation` instances directly down the call chain instead of repeatedly constructing new instances from raw string URIs at each recursive step.

---

## 🔬 Implementation Details

| Function | Type | Purpose |
| :--- | :--- | :--- |
| `isTermuxUrl(url)` | Helper | Safely checks whether a URI originates from Termux Document Provider. |
| `deleteDirOrFile(url, type)` | Helper | Asynchronously resolves stat/type checks, recursively deletes Termux trees or standard files, and performs state cleanup. |

<sub>(PR name and description are AI generated (Gemini 3.6 Flash))</sub>