### PR TITLE
Refactor conditions for preview release triggers

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,5 +1,7 @@
 # Implement to use environment secrets someday, At the moment GH Actions doesn't support those in reusable workflows (ref: https://github.com/actions/runner/issues/1490)
 # at least that's what I found.
+# This workflow executes PR Code when triggered from PR via workflow_call,
+# MUST approve the PR code BEFORE triggering this workflow.
 
 name: Nightly Build
 
@@ -101,6 +103,7 @@ jobs:
           fetch-depth: 0 # Required for tags
           persist-credentials: false
           ref: ${{ (inputs.is_PR && inputs.PR_NUMBER) && github.event.pull_request.head.sha || '' }}
+          allow-unsafe-pr-checkout: ${{ !!(inputs.is_PR && inputs.PR_NUMBER && github.event.pull_request.head.sha) }}
 
       - name: Setup Java
         uses: actions/setup-java@v5

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -25,9 +25,11 @@ jobs:
       issues: write
     if: >-
         github.event.pull_request.draft == false &&
-        github.repository_owner == 'Acode-Foundation' && 
-        (github.event.action == 'labeled' && github.event.label.name == 'CI: RUN ON-DEMAND PREVIEW RELEASES' || 
+        github.repository_owner == 'Acode-Foundation' &&
+        (!contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') &&
+          (github.event.action == 'labeled' && github.event.label.name == 'CI: RUN ON-DEMAND PREVIEW RELEASES' ||
           github.event.action == 'synchronize' && github.event.label.name == 'Bypass check - PREVIEW RELEASE')
+        )
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -1,6 +1,9 @@
 name: On Demand Preview Releases for PR
 #  avoids paths like .md, and anything in .github folder
 on:
+  # This workflow executes PR Code by checkout later
+  # MUST approve the PR Code BEFORE using this workflow on PRs.
+  # Uses this trigger to keep up-to-date execution of the workflow (triggers from Default Branch)
   pull_request_target:
     paths-ignore:
       - '!*.md'

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -31,7 +31,7 @@ jobs:
         github.repository_owner == 'Acode-Foundation' &&
         (!contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') &&
           (github.event.action == 'labeled' && github.event.label.name == 'CI: RUN ON-DEMAND PREVIEW RELEASES' ||
-          github.event.action == 'synchronize' && github.event.label.name == 'Bypass check - PREVIEW RELEASE')
+          github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE'))
         )
 
     runs-on: ubuntu-latest

--- a/.github/workflows/on-demand-preview-releases-PR.yml
+++ b/.github/workflows/on-demand-preview-releases-PR.yml
@@ -23,14 +23,11 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-    if: |
-        github.event.pull_request.draft == false
-        && (github.repository_owner == 'Acode-Foundation'
-        && (!contains(github.event.pull_request.labels.*.name, 'DO NOT PREVIEW RELEASE') 
-        && (contains(github.event.pull_request.labels.*.name, 'Bypass check - PREVIEW RELEASE') 
-          || contains(github.event.pull_request.labels.*.name, 'CI: RUN ON-DEMAND PREVIEW RELEASES')
-        ))
-        )
+    if: >-
+        github.event.pull_request.draft == false &&
+        github.repository_owner == 'Acode-Foundation' && 
+        (github.event.action == 'labeled' && github.event.label.name == 'CI: RUN ON-DEMAND PREVIEW RELEASES' || 
+          github.event.action == 'synchronize' && github.event.label.name == 'Bypass check - PREVIEW RELEASE')
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Clarifies PR workflow execution and approval process, 
adds `allow-unsafe-pr-checkout` to `nightly-build` checkouts when running from PR context.

Formats conditions for preview release triggers.

