### PR TITLE
Feat/lsp improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "plugins": {
       "cordova-clipboard": {},
       "cordova-plugin-device": {},
-      "cordova-plugin-file": {},
+      "cordova-plugin-file": {
+        "ANDROIDX_WEBKIT_VERSION": "1.4.0"
+      },
       "cordova-plugin-server": {},
       "cordova-plugin-ftp": {},
       "cordova-plugin-sdcard": {},
@@ -45,7 +47,9 @@
       "com.foxdebug.acode.rk.customtabs": {},
       "cordova-plugin-system": {},
       "cordova-plugin-crashhandler": {},
-      "cordova-plugin-advanced-http": {},
+      "cordova-plugin-advanced-http": {
+        "ANDROIDBLACKLISTSECURESOCKETPROTOCOLS": "SSLv3,TLSv1"
+      },
       "cordova-plugin-acode-webview": {}
     },
     "platforms": [

--- a/scripts/LS-SERVER-V2.txt
+++ b/scripts/LS-SERVER-V2.txt
@@ -1,0 +1,644 @@
+#!/data/data/com.termux/files/usr/bin/node
+process.on('uncaughtException', (err) => { if (err.code === 'EPIPE') return; console.error(err); });
+process.on('unhandledRejection', (err) => { if (err?.code === 'EPIPE') return; console.error(err); });
+
+
+import express from "express";
+import expressWs from "express-ws";
+import { spawn } from "node:child_process";
+// import Buffer from "node:buffer";
+
+import {
+  createConnection,
+  TextDocuments,
+  ProposedFeatures,
+  TextDocumentSyncKind
+} from "vscode-languageserver/node.js";
+
+import { getLanguageService as htmlLanguageServer } from "vscode-html-languageservice";
+import { TextDocument } from "vscode-languageserver-textdocument";
+
+import {
+  WebSocketMessageReader,
+  WebSocketMessageWriter
+} from "vscode-ws-jsonrpc";
+
+const DEBUG = true;
+const VERSION = "1.0.6";
+
+class WebSocketProxy extends EventTarget {
+  onopen;
+  onclose;
+  onerror;
+  onmessage;
+
+  constructor() {
+    super();
+
+    this.connection = null;
+    this.sendQueue = new Array();
+  }
+
+  get readyState() {
+    if (this.connection) {
+      return this.connection.readyState;
+    }
+    return 3;
+  }
+
+  initialize(connection) {
+    if (this.connection) {
+      this.connection.onclose = null;
+      this.connection.close();
+    }
+
+    this.connection = connection;
+    connection.onopen = event => {
+      this.dispatchEvent(new Event("open"));
+      this.onopen?.(event);
+
+      if (this.sendQueue.length) {
+        let newQueue = [...this.sendQueue];
+        this.sendQueue = [];
+        newQueue.map(data => this.send(data));
+      }
+    };
+
+    connection.onmessage = event => {
+      // console.log("[Received]:", event.data);
+      this.dispatchEvent(
+        new MessageEvent("message", {
+          data: event.data
+        })
+      );
+      this.onmessage?.(event);
+    };
+
+    connection.onclose = event => {
+      this.dispatchEvent(
+        new Event("close", {
+          reason: event.reason,
+          code: event.code,
+          wasClean: event.wasClean
+        })
+      );
+      this.onclose?.(event);
+    };
+
+    connection.onerror = error => {
+      this.dispatchEvent(new Event("error"));
+      this.onerror?.(error);
+    };
+  }
+
+  send(data) {
+    // console.log("[Sending]:", data);
+    if (this.connection) {
+      if (this.connection.readyState === 1) {
+        this.connection.send(data);
+      } else {
+        this.sendQueue.push(data);
+        console.log("[Server]", "WebSocket not open. Unable to send data.");
+      }
+    } else {
+      this.sendQueue.push(data);
+      this.connect();
+    }
+  }
+
+  close() {
+    if (this.connection) {
+      this.connection.close();
+    }
+  }
+}
+
+function sockWrapper(socket) {
+  return {
+    onMessage(callback) {
+      return socket.addEventListener("message", ({ data }) => {
+        callback(data);
+      });
+    },
+    onError(callback) {
+      return socket.addEventListener("error", callback);
+    },
+    onClose(callback) {
+      return socket.addEventListener("close", callback);
+    }
+  };
+}
+
+function addHeaders(data, sep) {
+  data = data.trim();
+  let length = Buffer.byteLength(data, 'utf8');
+  // console.log(data, data.length)
+  return "Content-Length: " + String(length) + sep + data;
+}
+
+function checkJSON(data) {
+  try {
+    JSON.parse(data);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function proxyServer(websocket, command, args, { callback, seperator } = {}) {
+  // Start the language server subprocess
+  const languageServer = spawn(command, args || [], {
+    stdio: ["pipe", "pipe", process.stderr]
+  });
+  let messageQueue = [],
+    spawned = false;
+
+  // Create separate streams for stdin and stdout
+  const stdinStream = languageServer.stdin;
+  const stdoutStream = languageServer.stdout;
+
+  let chunks = [];
+  let expectedLength = null;
+
+  // Pipe data from the WebSocket to the language server stdin
+  websocket.addEventListener("message", ({ data }) => {
+    // data = Buffer.from(data);
+    console.log("Incoming from client:", data);
+    if (callback) {
+      data = callback(data);
+    }
+    data = addHeaders(data, seperator || "\r\n\r\n");
+    // DEBUG && console.log("Received:", data);
+    if (spawned) {
+      stdinStream.write(data);
+    } else {
+      messageQueue.push(data);
+    }
+  });
+
+  let handleMessage = (dataString, dataLength) => {
+    if (!dataString) {
+      expectedLength = dataLength;
+      return;
+    }
+
+    // If currentMessage matches the local data length, send and return
+    if (
+      dataLength &&
+      (
+        dataString.length === dataLength ||
+        dataString.length === dataLength - 4
+      )
+    ) {
+      DEBUG && console.log("DSending:", dataString, checkJSON(dataString));
+      return websocket.send(dataString);
+    }
+
+    // If currentMessage matches the expected data length, send and return
+    if (
+      expectedLength &&
+      (
+        dataString.length === expectedLength ||
+        dataString.length === expectedLength - 4
+      )
+    ) {
+      DEBUG && console.log("ESending:", dataString, checkJSON(dataString));
+      return websocket.send(dataString);
+    }
+
+    // If no local data length use global expected length
+    if (!dataLength && expectedLength) {
+      dataLength = expectedLength;
+    }
+
+    // Else check if has previous message
+    if (chunks.length >= 1) {
+      // If previous message, check if current message plus previous messsges
+      // length matches the expected length
+      const completeMessage = chunks.join("") + dataString;
+      if (
+        completeMessage.length === dataLength ||
+        completeMessage.length === dataLength - 4
+      ) {
+        // Reset chunks array and expected length
+        chunks = [];
+        // expectedLength = null;
+
+        DEBUG &&
+          console.log("Sending:", completeMessage, checkJSON(completeMessage));
+        return websocket.send(completeMessage);
+      }
+    } else {
+      // Add the data to the chunks array
+      // and set global length to local length
+      chunks.push(dataString);
+      expectedLength = dataLength;
+    }
+  };
+
+  // Pipe data from the language server stdout to the WebSocket
+  stdoutStream.on("data", data => {
+    let dataString = data.toString();
+    DEBUG && console.log("Raw:", dataString);
+
+    // Check if the data contains 'Content-Length'
+    if (dataString.includes("Content-Length")) {
+      let messages = dataString.split("Content-Length:");
+      // console.log(messages);
+
+      for (let message of messages) {
+        if (!message?.length) continue;
+        DEBUG && console.log("\n\nHandling message:", message, expectedLength);
+
+        // Extract the content length
+        const contentLengthMatch = ("Content-Length:" + message).match(
+          /Content-Length: (\d+)/
+        );
+        if (contentLengthMatch) {
+          message = message.split("\r\n\r\n")[1];
+          handleMessage(message, parseInt(contentLengthMatch[1], 10));
+        } else {
+          handleMessage(message);
+        }
+      }
+    } else {
+      handleMessage(dataString);
+    }
+  });
+
+  // Handle the closure of WebSocket
+  websocket.addEventListener("close", () => {
+    // console.log("Closed websocket.")
+    languageServer.kill();
+  });
+
+  websocket.addEventListener("error", error => {
+    console.log("Error:", error);
+    // languageServer.kill();
+  });
+
+  languageServer.on("spawn", () => {
+    spawned = true;
+    messageQueue.map(data => stdinStream.write(data));
+    messageQueue = [];
+  });
+
+  languageServer.on("error", (...args) => {
+    console.log("Error in '" + command + "':", ...args);
+    websocket.close();
+  });
+
+  return languageServer;
+}
+
+const app = express();
+const port = 3030;
+
+let hasConfigurationCapability = false;
+let hasWorkspaceFolderCapability = false;
+let hasDiagnosticRelatedInformationCapability = false;
+
+const documentSettings = new Map();
+const documents = new TextDocuments(TextDocument);
+
+const servers = new Map();
+const serverModes = {
+  svelte: (socket, getConnection) => {
+    let ls = require("svelte-language-server/dist/src/server.js");
+    return ls.startServer({ connection: getConnection() });
+  },
+  cpp: (socket, getConnection) => {
+    return proxyServer(socket, "clangd", [], {
+      callback: data => {
+        return data.replaceAll('"uri":"/', '"uri":"file:///');
+      }
+    });
+  },
+  html: async (socket, getConnection) => {
+    let defaultSettings = { maxNumberOfProblems: 1000 };
+    let globalSettings = defaultSettings;
+
+    const service = htmlLanguageServer();
+
+    const connection = createConnection(
+      new WebSocketMessageReader(sockWrapper(socket)),
+      new WebSocketMessageWriter(socket),
+      ProposedFeatures.all
+    );
+
+    connection.onInitialize(params => {
+      const capabilities = params.capabilities;
+
+      // Does the client support the `workspace/configuration` request?
+      // If not, we fall back using global settings.
+      hasConfigurationCapability = !!(
+        capabilities.workspace && !!capabilities.workspace.configuration
+      );
+      hasWorkspaceFolderCapability = !!(
+        capabilities.workspace && !!capabilities.workspace.workspaceFolders
+      );
+      hasDiagnosticRelatedInformationCapability = !!(
+        capabilities.textDocument &&
+        capabilities.textDocument.publishDiagnostics &&
+        capabilities.textDocument.publishDiagnostics.relatedInformation
+      );
+
+      const result = {
+        capabilities: {
+          textDocumentSync: TextDocumentSyncKind.Incremental,
+          // Tell the client that this server supports code completion.
+          hoverProvider: true,
+          completionProvider: {
+            resolveProvider: true
+          },
+          workspace: {
+            workspaceFolders: {
+              supported: false,
+              changeNotifications: false
+            }
+          },
+          colorProvider: true
+        }
+      };
+      if (hasWorkspaceFolderCapability) {
+        result.capabilities.workspace = {
+          workspaceFolders: {
+            supported: true,
+            changeNotifications: true
+          }
+        };
+      }
+      return result;
+    });
+
+    // Cache the settings of all open documents
+    connection.onDidChangeConfiguration(change => {
+      if (hasConfigurationCapability) {
+        documentSettings.clear();
+      } else {
+        globalSettings = change.settings || defaultSettings;
+      }
+
+      // Revalidate all open text documents
+      // documents.all().forEach(validateTextDocument);
+    });
+
+    connection.onCompletion(params => {
+      let document = documents.get(params.textDocument.uri);
+      if (!document) return null;
+      let htmlDocument = service.parseHTMLDocument(document);
+      return service.doComplete(document, params.position, htmlDocument);
+    });
+
+    connection.onCompletionResolve(params => {
+      return params;
+    });
+
+    connection.onRenameRequest(params => {
+      let document = documents.get(params.textDocument.uri);
+      if (!document) return null;
+      let htmlDocument = service.parseHTMLDocument(document);
+      return service.doRename(
+        document,
+        params.position,
+        params.newName,
+        htmlDocument
+      );
+    });
+
+    connection.onDocumentHighlight(params => {
+      let document = documents.get(params.textDocument.uri);
+      if (!document) return null;
+      let htmlDocument = service.parseHTMLDocument(document);
+      return service.findDocumentHighlights(
+        document,
+        params.position,
+        htmlDocument
+      );
+    });
+
+    connection.onDocumentFormatting(params => {
+      let document = documents.get(params.textDocument.uri);
+      if (!document) return null;
+      return service.format(document, undefined, params.options);
+    });
+
+    connection.onRequest("textDocument/hover", params => {
+      let document = documents.get(params.textDocument.uri);
+      if (!document) return null;
+      let htmlDocument = service.parseHTMLDocument(document);
+      return service.doHover(document, params.position, htmlDocument);
+    });
+
+    // Only keep settings for open documents
+    documents.onDidClose(e => {
+      documentSettings.delete(e.document.uri);
+    });
+
+    // The content of a text document has changed. This event is emitted
+    // when the text document first opened or when its content has changed.
+    documents.onDidChangeContent(change => {
+      // validateTextDocument(change.document);
+    });
+
+    documents.listen(connection);
+    connection.listen();
+
+    return connection;
+  }
+  // typescript: async (socket, getConnection) => {
+  //   const { LspServer, LspClientImpl, LspClientLogger } = await import(
+  //     "./tslangserver.mjs"
+  //   );
+
+  //   const connection = createConnection(
+  //     new WebSocketMessageReader(sockWrapper(socket)),
+  //     new WebSocketMessageWriter(socket),
+  //     ProposedFeatures.all
+  //   );
+
+  //   const lspClient = new LspClientImpl(connection);
+  //   const logger = new LspClientLogger(lspClient);
+  //   const server = new LspServer({ logger, lspClient });
+  //   connection.onInitialize(server.initialize.bind(server));
+  //   connection.onInitialized(server.initialized.bind(server));
+  //   connection.onDidChangeConfiguration(
+  //     server.didChangeConfiguration.bind(server)
+  //   );
+  //   connection.onDidOpenTextDocument(server.didOpenTextDocument.bind(server));
+  //   connection.onDidSaveTextDocument(server.didSaveTextDocument.bind(server));
+  //   connection.onDidCloseTextDocument(server.didCloseTextDocument.bind(server));
+  //   connection.onDidChangeTextDocument(
+  //     server.didChangeTextDocument.bind(server)
+  //   );
+  //   connection.onCodeAction(server.codeAction.bind(server));
+  //   connection.onCodeLens(server.codeLens.bind(server));
+  //   connection.onCodeLensResolve(server.codeLensResolve.bind(server));
+  //   connection.onCompletion(server.completion.bind(server));
+  //   connection.onCompletionResolve(server.completionResolve.bind(server));
+  //   connection.onDefinition(server.definition.bind(server));
+  //   connection.onImplementation(server.implementation.bind(server));
+  //   connection.onTypeDefinition(server.typeDefinition.bind(server));
+  //   connection.onDocumentFormatting(server.documentFormatting.bind(server));
+  //   connection.onDocumentRangeFormatting(
+  //     server.documentRangeFormatting.bind(server)
+  //   );
+  //   connection.onDocumentHighlight(server.documentHighlight.bind(server));
+  //   connection.onDocumentSymbol(server.documentSymbol.bind(server));
+  //   connection.onExecuteCommand(server.executeCommand.bind(server));
+  //   connection.onHover(server.hover.bind(server));
+  //   connection.onReferences(server.references.bind(server));
+  //   connection.onRenameRequest(server.rename.bind(server));
+  //   connection.onPrepareRename(server.prepareRename.bind(server));
+  //   connection.onSelectionRanges(server.selectionRanges.bind(server));
+  //   connection.onSignatureHelp(server.signatureHelp.bind(server));
+  //   connection.onWorkspaceSymbol(server.workspaceSymbol.bind(server));
+  //   connection.onFoldingRanges(server.foldingRanges.bind(server));
+  //   connection.languages.onLinkedEditingRange(
+  //     server.linkedEditingRange.bind(server)
+  //   );
+  //   connection.languages.callHierarchy.onPrepare(
+  //     server.prepareCallHierarchy.bind(server)
+  //   );
+  //   connection.languages.callHierarchy.onIncomingCalls(
+  //     server.callHierarchyIncomingCalls.bind(server)
+  //   );
+  //   connection.languages.callHierarchy.onOutgoingCalls(
+  //     server.callHierarchyOutgoingCalls.bind(server)
+  //   );
+  //   connection.languages.inlayHint.on(server.inlayHints.bind(server));
+  //   connection.languages.semanticTokens.on(
+  //     server.semanticTokensFull.bind(server)
+  //   );
+  //   connection.languages.semanticTokens.onRange(
+  //     server.semanticTokensRange.bind(server)
+  //   );
+  //   connection.workspace.onWillRenameFiles(server.willRenameFiles.bind(server));
+
+  //   socket.addEventListener("close", () => {
+  //     connection.dispose();
+  //   });
+  //   connection.listen();
+  // },
+  // python: (socket, getConnection) => {
+  //   return proxyServer(socket, "pylsp", ["--check-parent-process"]);
+  // },
+  // java: (socket, getConnection) => {
+  //   return proxyServer(socket, "~/jdtls/bin/jdtls", [], {
+  //     callback: data => {
+  //       return data
+  //         .replaceAll('"uri":"/', '"uri":"file:///')
+  //         .replaceAll('"url":"/', '"url":"file:///');
+  //     }
+  //   });
+  // },
+  // rust: (socket, getConnection) => {
+  //   return proxyServer(socket, "rust-analyzer", [], {
+  //     callback: data => {
+  //       return data
+  //         .replaceAll('"uri":"/', '"uri":"file:///')
+  //         .replaceAll('"url":"/', '"url":"file:///');
+  //     },
+  //     seperator: "\n\n"
+  //   });
+  // },
+  // vue: (socket, getConnection) => {
+  //   return proxyServer(socket, "vls", [], {
+  //     callback: data => {
+  //       return data
+  //         .replaceAll('"uri":"/', '"uri":"file:///')
+  //         .replaceAll('"url":"/', '"url":"file:///');
+  //     }
+  //   });
+  // }
+};
+
+// Enable WebSocket support
+expressWs(app);
+
+app.get("/version", (request, response) => {
+  response.send(VERSION);
+});
+
+// WebSocket endpoint
+app.ws("/server/:mode", async (socket, req) => {
+  let mode = req.params.mode;
+  let module = serverModes[mode];
+  if (!module) return;
+
+  console.log("Connecting to client:", mode);
+  let currentServer = servers.get(mode),
+    proxySocket;
+  if (!currentServer) {
+    proxySocket = new WebSocketProxy();
+    proxySocket.initialize(socket);
+
+    let server = await module(proxySocket, (...args) =>
+      createConnection(
+        new WebSocketMessageReader(sockWrapper(proxySocket)),
+        new WebSocketMessageWriter(proxySocket),
+        ...args
+      )
+    );
+
+    if (server) {
+      servers.set(mode, { proxySocket, server });
+    }
+  } else {
+    proxySocket = currentServer.proxySocket;
+    proxySocket.initialize(socket);
+  }
+});
+
+app.ws("/auto/*", async (socket, request) => {
+  let paramCommand = decodeURIComponent(request.params[0]);
+  let [command, ...args] = paramCommand.split(" ");
+
+  const currentServer = servers.get(command);
+
+  // Any new websocket connection is a brand-new LSP session as far as the
+  // client is concerned (it will send a fresh "initialize"). Reusing a
+  // still-initialized child process for that breaks servers that reject
+  // a second initialize (e.g. phpactor). So evict and kill synchronously
+  // instead of waiting on the old process's async "close" event, which
+  // can race with this new connection.
+  if (currentServer) {
+    console.log("Restarting process for '" + command + "' (new session)");
+    servers.delete(command);
+    currentServer.proxySocket.close();
+    currentServer.server.kill();
+  }
+
+  const proxySocket = new WebSocketProxy();
+  console.log("Connecting to auto client:", command, request.query.args || []);
+
+  const server = proxyServer(
+    proxySocket,
+    command,
+    request.query.args ? JSON.parse(request.query.args) : args,
+    {
+      callback: data => {
+        if (request.query.rawuri === "true") return data;
+        return data
+          .replaceAll('uri":"/', 'uri":"file:///')
+          .replaceAll('url":"/', 'url":"file:///');
+      }
+    }
+  );
+
+  if (server) {
+    servers.set(command, { proxySocket, server });
+    server.on("close", () => {
+      console.log("Closing process for '" + command + "'");
+      servers.delete(command);
+      proxySocket.close();
+    });
+  }
+
+  proxySocket.initialize(socket);
+});
+
+// Start the server
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/scripts/LS-SERVER-V2.txt
+++ b/scripts/LS-SERVER-V2.txt
@@ -176,65 +176,50 @@ function proxyServer(websocket, command, args, { callback, seperator } = {}) {
     }
   });
 
-  let handleMessage = (dataString, dataLength) => {
-    if (!dataString) {
-      expectedLength = dataLength;
-      return;
-    }
+ let handleMessage = (dataString, dataLength) => {
+  if (!dataString) {
+    expectedLength = dataLength;
+    return;
+  }
 
-    // If currentMessage matches the local data length, send and return
+  const dataByteLength = Buffer.byteLength(dataString, 'utf8');
+
+  if (
+    dataLength &&
+    (dataByteLength === dataLength || dataByteLength === dataLength - 4)
+  ) {
+    DEBUG && console.log("DSending:", dataString, checkJSON(dataString));
+    return websocket.send(dataString);
+  }
+
+  if (
+    expectedLength &&
+    (dataByteLength === expectedLength || dataByteLength === expectedLength - 4)
+  ) {
+    DEBUG && console.log("ESending:", dataString, checkJSON(dataString));
+    return websocket.send(dataString);
+  }
+
+  if (!dataLength && expectedLength) {
+    dataLength = expectedLength;
+  }
+
+  if (chunks.length >= 1) {
+    const completeMessage = chunks.join("") + dataString;
+    const completeByteLength = Buffer.byteLength(completeMessage, 'utf8');
     if (
-      dataLength &&
-      (
-        dataString.length === dataLength ||
-        dataString.length === dataLength - 4
-      )
+      completeByteLength === dataLength ||
+      completeByteLength === dataLength - 4
     ) {
-      DEBUG && console.log("DSending:", dataString, checkJSON(dataString));
-      return websocket.send(dataString);
+      chunks = [];
+      DEBUG && console.log("Sending:", completeMessage, checkJSON(completeMessage));
+      return websocket.send(completeMessage);
     }
-
-    // If currentMessage matches the expected data length, send and return
-    if (
-      expectedLength &&
-      (
-        dataString.length === expectedLength ||
-        dataString.length === expectedLength - 4
-      )
-    ) {
-      DEBUG && console.log("ESending:", dataString, checkJSON(dataString));
-      return websocket.send(dataString);
-    }
-
-    // If no local data length use global expected length
-    if (!dataLength && expectedLength) {
-      dataLength = expectedLength;
-    }
-
-    // Else check if has previous message
-    if (chunks.length >= 1) {
-      // If previous message, check if current message plus previous messsges
-      // length matches the expected length
-      const completeMessage = chunks.join("") + dataString;
-      if (
-        completeMessage.length === dataLength ||
-        completeMessage.length === dataLength - 4
-      ) {
-        // Reset chunks array and expected length
-        chunks = [];
-        // expectedLength = null;
-
-        DEBUG &&
-          console.log("Sending:", completeMessage, checkJSON(completeMessage));
-        return websocket.send(completeMessage);
-      }
-    } else {
-      // Add the data to the chunks array
-      // and set global length to local length
-      chunks.push(dataString);
-      expectedLength = dataLength;
-    }
-  };
+  } else {
+    chunks.push(dataString);
+    expectedLength = dataLength;
+  }
+};
 
   // Pipe data from the language server stdout to the WebSocket
   stdoutStream.on("data", data => {

--- a/scripts/patch-acodels.sh
+++ b/scripts/patch-acodels.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -eu
+
+die() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
+}
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SOURCE_FILE="$SCRIPT_DIR/LS-SERVER-V2.txt"
+PKG_NAME="acode-lsp"
+
+command -v node >/dev/null 2>&1 || die "node is not installed or not in PATH."
+command -v npm >/dev/null 2>&1 || die "npm is not installed or not in PATH."
+
+[ -f "$SOURCE_FILE" ] || die "Missing patch file: $SOURCE_FILE"
+
+NODE_PATH=$(command -v node)
+
+# Try to find the installed executable first.
+TARGET_BIN=$(command -v acode-ls 2>/dev/null || command -v acode-lsp 2>/dev/null || true)
+
+# If not installed, install it globally.
+if [ -z "$TARGET_BIN" ]; then
+  printf 'acode-ls not found in PATH. Installing %s globally...\n' "$PKG_NAME"
+  npm install -g "$PKG_NAME"
+  TARGET_BIN=$(command -v acode-ls 2>/dev/null || command -v acode-lsp 2>/dev/null || true)
+fi
+
+[ -n "$TARGET_BIN" ] || die "acode-ls/acode-lsp is still not found after installation."
+
+printf 'Found target executable at: %s\n' "$TARGET_BIN"
+printf 'Using node at: %s\n' "$NODE_PATH"
+
+BACKUP_FILE="$TARGET_BIN.backup"
+if [ -e "$BACKUP_FILE" ]; then
+  BACKUP_FILE="$TARGET_BIN.backup.$(date +%Y%m%d%H%M%S)"
+fi
+
+cp "$TARGET_BIN" "$BACKUP_FILE"
+
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT INT HUP TERM
+
+# Replace the first line (shebang) with the current system node path.
+first_line=$(head -n 1 "$SOURCE_FILE" || true)
+if printf '%s' "$first_line" | grep -q '^#!'; then
+  {
+    printf '#!%s\n' "$NODE_PATH"
+    tail -n +2 "$SOURCE_FILE"
+  } > "$TMP_FILE"
+else
+  {
+    printf '#!%s\n' "$NODE_PATH"
+    cat "$SOURCE_FILE"
+  } > "$TMP_FILE"
+fi
+
+cp "$TMP_FILE" "$TARGET_BIN"
+chmod +x "$TARGET_BIN"
+
+printf 'Patch applied successfully.\n'
+printf 'Backup saved at: %s\n' "$BACKUP_FILE"
+printf 'Done :)\\n'

--- a/src/cm/lsp/clientManager.ts
+++ b/src/cm/lsp/clientManager.ts
@@ -6,7 +6,8 @@ import {
   serverCompletion,
   serverDiagnostics,
 } from "@codemirror/lsp-client";
-import { EditorState, Extension, Facet, MapMode } from "@codemirror/state";
+//import { EditorState, Extension, Facet, MapMode, Text } from "@codemirror/state";
+import { EditorState, Extension, Facet } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import lspStatusBar from "components/lspStatusBar";
 import notificationManager from "lib/notificationManager";
@@ -49,6 +50,10 @@ import type {
   Transport,
 } from "./types";
 import AcodeWorkspace from "./workspace";
+//new
+import { applyTextEdits, safeLspPositionToOffset } from "./textEditUtils";
+
+const LSP_IDLE_GRACE_MS = 45_000; // grace period before a client with no open files is actually disposed
 
 export const lspCompletionEnabled = Facet.define<boolean, boolean>({
   // File-level marker used by the autocomplete override path. If any attached
@@ -129,10 +134,16 @@ function isSettingsOrKeybindingsFile(
 }
 
 function isVerboseLspLoggingEnabled(): boolean {
+  return true; // TEMP: force verbose LSP logging for debugging
+}
+
+/*
+function isVerboseLspLoggingEnabled(): boolean {
   const buildInfo = (globalThis as { BuildInfo?: { debug?: boolean } })
     .BuildInfo;
   return !!buildInfo?.debug;
 }
+*/
 
 function logLspInfo(...args: unknown[]): void {
   if (!isVerboseLspLoggingEnabled()) return;
@@ -491,6 +502,25 @@ export class LspClientManager {
         const plugin = LSPPlugin.get(view);
         if (!plugin) continue;
         plugin.client.sync();
+        console.log(
+  "Current length",
+  view.state.doc.length,
+);
+
+console.log(
+  "Synced length",
+  plugin.syncedDoc.length,
+);
+
+console.log(
+  "Current doc\n",
+  view.state.doc.toString(),
+);
+
+console.log(
+  "Synced doc\n",
+  plugin.syncedDoc.toString(),
+);
         const edits = await state.client.request<
           { textDocument: { uri: string }; options: FormattingOptions },
           TextEdit[] | null
@@ -985,6 +1015,7 @@ export class LspClientManager {
         serverId: server.id,
         allowNonTerminalWorkspace:
           this.options.allowNonTerminalWorkspace === true,
+        //resolveViewForUri: (uri: string) => clientState.getAttachedView?.(uri) ?? null,
       };
       const connection = await runtimeProvider.start(server, runtimeContext);
       const connectionDispose = connection.dispose;
@@ -1013,13 +1044,15 @@ export class LspClientManager {
       connectClient(client, transportHandle.transport, initializationOptions);
       await waitForInitialization(client.initializing, signal, server.id);
       // New: push config the same way ALC always did
-      if (server.workspaceConfiguration) {
-        transportHandle.transport.send(JSON.stringify({
-          jsonrpc: "2.0",
-          method: "workspace/didChangeConfiguration",
-          params: { settings: server.workspaceConfiguration },
-        }));
-      };
+      console.log("### CONFIG PUSH ATTEMPT ###");
+      // Fire after "initialized" — reuse initializationOptions as the config payload,
+      // since that's the field you actually populate via the wizard
+      transportHandle.transport.send(JSON.stringify({
+        jsonrpc: "2.0",
+        method: "workspace/didChangeConfiguration",
+        params: { settings: server.initializationOptions ?? {} },
+      }));
+      console.log("### CONFIG PUSH SENT ###");
       if (!client.__acodeLoggedInfo) {
         // Log root URI info to console
         if (normalizedRootUri) {
@@ -1096,8 +1129,9 @@ export class LspClientManager {
     const uriAliases = new Map<string, string>();
     const effectiveRoot = normalizedRootUri ?? originalRootUri ?? null;
     let disposed = false;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
 
-    const attach = (
+    /* const attach = (
       uri: string,
       view: EditorView,
       aliases: string[] = [],
@@ -1112,11 +1146,35 @@ export class LspClientManager {
       }
       const suffix = effectiveRoot ? ` (root ${effectiveRoot})` : "";
       logLspInfo(`[LSP:${server.id}] attached to ${uri}${suffix}`);
-    };
+    }; */
+    const attach = (
+  uri: string,
+  view: EditorView,
+  aliases: string[] = [],
+): void => {
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = undefined;
+  }
+  const existing = fileRefs.get(uri) ?? new Set();
+  existing.add(view);
+  fileRefs.set(uri, existing);
+  uriAliases.set(uri, uri);
+  for (const alias of aliases) {
+    if (!alias || alias === uri) continue;
+    uriAliases.set(alias, uri);
+  }
+  const suffix = effectiveRoot ? ` (root ${effectiveRoot})` : "";
+  logLspInfo(`[LSP:${server.id}] attached to ${uri}${suffix}`);
+};
 
     const dispose = async (): Promise<void> => {
       if (disposed) return;
       disposed = true;
+      if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = undefined;
+  }
       disposePullDiagnostics(client);
       this.#clients.delete(key);
       try {
@@ -1153,13 +1211,18 @@ export class LspClientManager {
       }
 
       if (!fileRefs.size) {
-        this.options.onClientIdle?.({
-          server,
-          client,
-          rootUri: effectiveRoot,
-          dispose,
-        });
-      }
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    idleTimer = undefined;
+    if (fileRefs.size) return; // a file reattached during the grace window
+    this.options.onClientIdle?.({
+      server,
+      client,
+      rootUri: effectiveRoot,
+      dispose,
+    });
+  }, LSP_IDLE_GRACE_MS);
+}
     };
 
     return {
@@ -1351,45 +1414,6 @@ interface Change {
   insert: string;
 }
 
-function applyTextEdits(
-  plugin: LSPPlugin,
-  view: EditorView,
-  edits: TextEdit[],
-): boolean {
-  const changes: Change[] = [];
-  for (const edit of edits) {
-    if (!edit?.range) continue;
-    let fromBase: number;
-    let toBase: number;
-    try {
-      fromBase = plugin.fromPosition(edit.range.start, plugin.syncedDoc);
-      toBase = plugin.fromPosition(edit.range.end, plugin.syncedDoc);
-    } catch (_) {
-      continue;
-    }
-    const fromResult = plugin.unsyncedChanges.mapPos(
-      fromBase,
-      1,
-      MapMode.TrackDel,
-    );
-    const toResult = plugin.unsyncedChanges.mapPos(
-      toBase,
-      -1,
-      MapMode.TrackDel,
-    );
-    if (fromResult == null || toResult == null) continue;
-    const insert =
-      typeof edit.newText === "string"
-        ? edit.newText.replace(/\r\n/g, "\n")
-        : "";
-    changes.push({ from: fromResult, to: toResult, insert });
-  }
-  if (!changes.length) return false;
-  changes.sort((a, b) => a.from - b.from || a.to - b.to);
-  view.dispatch({ changes });
-  return true;
-}
-
 function buildFormattingOptions(
   view: EditorView,
   overrides: FormattingOptions = {},
@@ -1428,6 +1452,7 @@ function resolveIndentWidth(unit: string): number {
   }
   return width || 4;
 }
+
 
 const defaultManager = new LspClientManager();
 

--- a/src/cm/lsp/clientManager.ts
+++ b/src/cm/lsp/clientManager.ts
@@ -1593,14 +1593,6 @@ function contentUriToFileUri(uri: string): string | null {
         }
         if (!normalized.startsWith("/")) return null;
         return buildFileUri(normalized);
-      case "termux":
-        normalized = normalized.replace(/:+$/, "");
-        if (!normalized) return null;
-        try {
-          normalized = decodeURIComponent(normalized);
-        } catch (_) {
-          // already decoded, or not encoded at all — use as-is
-        }
       case "android.externalstorage":
         normalized = normalized.replace(/:+$/, "");
         if (!normalized) return null;

--- a/src/cm/lsp/clientManager.ts
+++ b/src/cm/lsp/clientManager.ts
@@ -1472,6 +1472,15 @@ function normalizeRootUriForServer(
   if (scheme === "file") {
     return { normalizedRootUri: rootUri, originalRootUri: rootUri };
   }
+  
+  // sftp roots: strip to the bare remote path
+  if (scheme === "sftp") {
+    const fileUri = sftpUriToFileUri(rootUri);
+    if (fileUri) {
+      return { normalizedRootUri: fileUri, originalRootUri: rootUri };
+    }
+    return { normalizedRootUri: null, originalRootUri: rootUri };
+  }
 
   // Try to convert content:// URIs to file:// URIs
   if (scheme === "content") {
@@ -1497,6 +1506,12 @@ function normalizeDocumentUri(uri: string | null | undefined): string | null {
   if (scheme === "file" || scheme === "untitled") {
     return uri;
   }
+  
+  // sftp documents: strip to the bare remote path
+  if (scheme === "sftp") {
+    return sftpUriToFileUri(uri);
+  }
+
 
   // Convert content:// URIs to file:// URIs
   if (scheme === "content") {
@@ -1543,6 +1558,14 @@ function contentUriToFileUri(uri: string): string | null {
         }
         if (!normalized.startsWith("/")) return null;
         return buildFileUri(normalized);
+      case "termux":
+        normalized = normalized.replace(/:+$/, "");
+        if (!normalized) return null;
+        try {
+          normalized = decodeURIComponent(normalized);
+        } catch (_) {
+          // already decoded, or not encoded at all — use as-is
+        }
       case "android.externalstorage":
         normalized = normalized.replace(/:+$/, "");
         if (!normalized) return null;
@@ -1581,6 +1604,17 @@ function contentUriToFileUri(uri: string): string | null {
   } catch (_) {
     return null;
   }
+}
+
+function sftpUriToFileUri(uri: string): string | null {
+  // acode-ls and the LSP process it spawns run on the same remote host
+  // reached via this SFTP connection, so the server needs only the bare
+  // remote path — no scheme, host, port, or credentials.
+  const match = /^sftp:\/\/[^/]*(\/.*)$/.exec(uri);
+  if (!match) return null;
+  const path = match[1].split("?")[0];
+  if (!path) return null;
+  return buildFileUri(path);
 }
 
 function buildFileUri(pathname: string): string | null {

--- a/src/cm/lsp/clientManager.ts
+++ b/src/cm/lsp/clientManager.ts
@@ -1012,6 +1012,14 @@ export class LspClientManager {
       client.__acodeServerId = server.id;
       connectClient(client, transportHandle.transport, initializationOptions);
       await waitForInitialization(client.initializing, signal, server.id);
+      // New: push config the same way ALC always did
+      if (server.workspaceConfiguration) {
+        transportHandle.transport.send(JSON.stringify({
+          jsonrpc: "2.0",
+          method: "workspace/didChangeConfiguration",
+          params: { settings: server.workspaceConfiguration },
+        }));
+      };
       if (!client.__acodeLoggedInfo) {
         // Log root URI info to console
         if (normalizedRootUri) {

--- a/src/cm/lsp/clientManager.ts
+++ b/src/cm/lsp/clientManager.ts
@@ -189,8 +189,16 @@ function connectClient(
   client: ExtendedLSPClient,
   transport: Transport,
   initializationOptions?: Record<string, unknown>,
+  rootUri?: string | null,
 ): void {
-  if (!initializationOptions || !Object.keys(initializationOptions).length) {
+  const workspaceFolders = rootUri
+    ? [{ uri: rootUri, name: deriveFolderName(rootUri) }]
+    : undefined;
+
+  if (
+    (!initializationOptions || !Object.keys(initializationOptions).length) &&
+    !workspaceFolders
+  ) {
     client.connect(transport);
     return;
   }
@@ -210,7 +218,8 @@ function connectClient(
     if (method === "initialize" && isPlainObject(params)) {
       params = {
         ...params,
-        initializationOptions,
+        ...(initializationOptions ? { initializationOptions } : {}),
+        ...(workspaceFolders ? { workspaceFolders } : {}),
       } as Params;
     }
     return originalRequestInner<Params, Result>(method, params, mapped);
@@ -220,6 +229,17 @@ function connectClient(
     client.connect(transport);
   } finally {
     patchedClient.requestInner = originalRequestInner;
+  }
+}
+
+function deriveFolderName(uri: string): string {
+  try {
+    const decoded = decodeURIComponent(uri);
+    const trimmed = decoded.replace(/\/+$/, "");
+    const segments = trimmed.split("/").filter(Boolean);
+    return segments[segments.length - 1] || decoded;
+  } catch {
+    return uri;
   }
 }
 
@@ -794,6 +814,16 @@ console.log(
         },
         workspace: {
           configuration: true,
+          applyEdit: true,
+          workspaceFolders: true,
+        },
+        textDocument: {
+          codeAction: {
+            dataSupport: true,
+            resolveSupport: {
+              properties: ["edit"],
+            },
+          },
         },
       },
     };
@@ -1041,7 +1071,12 @@ console.log(
       await waitForInitialization(transportHandle.ready, signal, server.id);
       client = new LSPClient(clientConfig) as ExtendedLSPClient;
       client.__acodeServerId = server.id;
-      connectClient(client, transportHandle.transport, initializationOptions);
+      connectClient(
+  client,
+  transportHandle.transport,
+  initializationOptions,
+  normalizedRootUri,
+);
       await waitForInitialization(client.initializing, signal, server.id);
       // New: push config the same way ALC always did
       console.log("### CONFIG PUSH ATTEMPT ###");

--- a/src/cm/lsp/codeActions.ts
+++ b/src/cm/lsp/codeActions.ts
@@ -14,6 +14,8 @@ import type {
 import type { Position, Range } from "./types";
 import { addLspLogFor } from "./logs";
 import type AcodeWorkspace from "./workspace";
+import { getLspDiagnostics } from "./diagnostics";
+import type { LspDiagnostic } from "./types";
 
 type CodeActionResponse = (CodeAction | Command)[] | null;
 
@@ -38,6 +40,33 @@ const CODE_ACTION_ICONS: Record<string, string> = {
 	"source.organizeImports": "sort",
 	"source.fixAll": "done_all",
 };
+// Add near the top of codeActions.ts, or reuse if something equivalent exists:
+const severityMap: Record<string, number> = {
+  error: 1,
+  warning: 2,
+  info: 3,
+  hint: 4,
+};
+
+function toWireDiagnostics(
+  plugin: LSPPlugin,
+  diagnostics: LspDiagnostic[],
+): Diagnostic[] {
+  return diagnostics.map((d) => ({
+    range: { start: plugin.toPosition(d.from), end: plugin.toPosition(d.to) },
+    message: d.message,
+    severity: severityMap[d.severity] ?? 1,
+    source: d.source,
+  }));
+}
+function comparePositions(a: LspPosition, b: LspPosition): number {
+  if (a.line !== b.line) return a.line - b.line;
+  return a.character - b.character;
+}
+
+function rangesOverlap(a: LspRange, b: LspRange): boolean {
+  return comparePositions(a.start, b.end) <= 0 && comparePositions(b.start, a.end) <= 0;
+}
 
 function getCodeActionIcon(kind?: CodeActionKind): string {
 	if (!kind) return "icon zap";
@@ -299,11 +328,21 @@ export async function fetchCodeActions(
 		start: plugin.toPosition(from),
 		end: plugin.toPosition(to),
 	};
+	
+	const allDiagnostics = getLspDiagnostics(view.state);
+console.log("[CodeAction debug] all diagnostics:", allDiagnostics);
+console.log("[CodeAction debug] requested offsets:", from, to);
+const overlapping = allDiagnostics.filter((d) => d.to >= from && d.from <= to);
+console.log("[CodeAction debug] overlapping after filter:", overlapping);
+  const wireDiagnostics = toWireDiagnostics(plugin, overlapping);
 
 	plugin.client.sync();
 
 	try {
-		const response = await requestCodeActions(plugin, range);
+	  ////const allDiagnostics = view.state.field(lspPublishedDiagnostics, false) ?? [];
+    ////const overlapping = allDiagnostics.filter(d => rangesOverlap(d.range, range)); // range-overlap check needed
+    const response = await requestCodeActions(plugin, range, wireDiagnostics);
+		//const response = await requestCodeActions(plugin, range);
 		if (!response?.length) return [];
 
 		const items: CodeActionItem[] = response.map((item) => {

--- a/src/cm/lsp/definition.ts
+++ b/src/cm/lsp/definition.ts
@@ -1,0 +1,145 @@
+import { LSPPlugin } from "@codemirror/lsp-client";
+import type { EditorView } from "@codemirror/view";
+import { showReferencesPanel } from "components/referencesPanel";
+import { fetchLineText, getWordAtCursor } from "./references";
+import toast from "components/toast";
+
+interface Position {
+	line: number;
+	character: number;
+}
+
+interface Range {
+	start: Position;
+	end: Position;
+}
+
+interface Location {
+	uri: string;
+	range: Range;
+}
+
+interface LocationLink {
+	targetUri: string;
+	targetRange: Range;
+	targetSelectionRange?: Range;
+}
+
+type DefinitionResult = Location | Location[] | LocationLink[] | null;
+
+interface ReferenceWithContext extends Location {
+	lineText?: string;
+}
+
+type DefinitionKind =
+	| "definition"
+	| "declaration"
+	| "implementation"
+	| "typeDefinition";
+
+const CAPABILITY_KEY: Record<DefinitionKind, string> = {
+	definition: "definitionProvider",
+	declaration: "declarationProvider",
+	implementation: "implementationProvider",
+	typeDefinition: "typeDefinitionProvider",
+};
+
+const LABEL: Record<DefinitionKind, string> = {
+	definition: "definition",
+	declaration: "declaration",
+	implementation: "implementation",
+	typeDefinition: "type definition",
+};
+
+function normalizeLocations(result: DefinitionResult): Location[] {
+	if (!result) return [];
+	const list = Array.isArray(result) ? result : [result];
+	return list.map((item) => {
+		if ("targetUri" in item) {
+			return {
+				uri: item.targetUri,
+				range: item.targetSelectionRange ?? item.targetRange,
+			};
+		}
+		return item;
+	});
+}
+
+async function fetchLocations(
+	view: EditorView,
+	kind: DefinitionKind,
+): Promise<Location[] | null> {
+	const plugin = LSPPlugin.get(view);
+	if (!plugin) return null;
+
+	const client = plugin.client;
+	const capabilities = client.serverCapabilities as
+		| Record<string, unknown>
+		| undefined;
+
+	if (!capabilities?.[CAPABILITY_KEY[kind]]) {
+		toast(`Language server does not support go to ${LABEL[kind]}`);
+		return null;
+	}
+
+	const { state } = view;
+	const pos = state.selection.main.head;
+	const line = state.doc.lineAt(pos);
+	const uri = plugin.uri;
+
+	client.sync();
+
+	const method = `textDocument/${kind}`;
+	const params = {
+		textDocument: { uri },
+		position: { line: line.number - 1, character: pos - line.from },
+	};
+
+	const result = await client.request<typeof params, DefinitionResult>(
+		method,
+		params,
+	);
+
+	return normalizeLocations(result);
+}
+
+async function goTo(view: EditorView, kind: DefinitionKind): Promise<boolean> {
+	try {
+		const locations = await fetchLocations(view, kind);
+		if (locations === null) return false;
+
+		if (locations.length === 0) {
+			toast(`No ${LABEL[kind]} found`);
+			return false;
+		}
+
+		if (locations.length === 1) {
+			const { navigateToReference } = await import(
+				"components/referencesPanel/utils"
+			);
+			await navigateToReference(locations[0]);
+			return true;
+		}
+
+		const symbolName = getWordAtCursor(view);
+		const panel = showReferencesPanel({ symbolName });
+		const withContext: ReferenceWithContext[] = await Promise.all(
+			locations.map(async (loc) => ({
+				...loc,
+				lineText: await fetchLineText(loc.uri, loc.range.start.line),
+			})),
+		);
+		panel.setReferences(withContext);
+		return true;
+	} catch (error) {
+		console.error(`Go to ${LABEL[kind]} failed:`, error);
+		return false;
+	}
+}
+
+export const goToDefinition = (view: EditorView) => goTo(view, "definition");
+export const goToDeclaration = (view: EditorView) => goTo(view, "declaration");
+export const goToImplementation = (view: EditorView) =>
+	goTo(view, "implementation");
+export const goToTypeDefinition = (view: EditorView) =>
+	goTo(view, "typeDefinition");

--- a/src/cm/lsp/index.ts
+++ b/src/cm/lsp/index.ts
@@ -90,6 +90,12 @@ export {
 	findAllReferencesInTab,
 } from "./references";
 export {
+	goToDefinition,
+	goToDeclaration,
+	goToImplementation,
+	goToTypeDefinition,
+} from "./definition";
+export {
 	acodeRenameExtension,
 	acodeRenameKeymap,
 	renameSymbol,

--- a/src/cm/lsp/references.ts
+++ b/src/cm/lsp/references.ts
@@ -33,7 +33,7 @@ interface ReferenceParams {
 	context: { includeDeclaration: boolean };
 }
 
-async function fetchLineText(uri: string, line: number): Promise<string> {
+export async function fetchLineText(uri: string, line: number): Promise<string> {
 	try {
 		interface EditorManagerLike {
 			getFile?: (uri: string, type: string) => EditorFileLike | null;
@@ -89,7 +89,7 @@ async function fetchLineText(uri: string, line: number): Promise<string> {
 	return "";
 }
 
-function getWordAtCursor(view: EditorView): string {
+export function getWordAtCursor(view: EditorView): string {
 	const { state } = view;
 	const pos = state.selection.main.head;
 	const word = state.wordAt(pos);

--- a/src/cm/lsp/textEditUtils.ts
+++ b/src/cm/lsp/textEditUtils.ts
@@ -1,0 +1,72 @@
+import type { LSPPlugin } from "@codemirror/lsp-client";
+import type { EditorView } from "@codemirror/view";
+import { MapMode } from "@codemirror/state";
+import type { Text } from "@codemirror/state";
+import type { TextEdit } from "vscode-languageserver-types";
+
+interface Change {
+	from: number;
+	to: number;
+	insert: string;
+}
+
+/**
+ * Convert an LSP Position to a CodeMirror document offset, clamping to
+ * document bounds. Handles the LSP convention where line == doc.lines
+ * means "end of document" (e.g. full-document formatting replacements).
+ */
+export function safeLspPositionToOffset(
+	doc: Text,
+	pos: { line: number; character: number },
+): number {
+	if (pos.line < 0) return 0;
+	if (pos.line >= doc.lines) return doc.length;
+	const line = doc.line(pos.line + 1);
+	return line.from + Math.min(pos.character, line.length);
+}
+
+/**
+ * Apply a list of LSP TextEdits to an EditorView backed by the given
+ * LSPPlugin. Shared by clientManager.ts (edits the client pulls, e.g.
+ * textDocument/formatting) and transport.ts (edits the server pushes,
+ * e.g. workspace/applyEdit).
+ */
+export function applyTextEdits(
+	plugin: LSPPlugin,
+	view: EditorView,
+	edits: TextEdit[],
+): boolean {
+	const changes: Change[] = [];
+	for (const edit of edits) {
+		if (!edit?.range) continue;
+		let fromBase: number;
+		let toBase: number;
+		try {
+			fromBase = safeLspPositionToOffset(plugin.syncedDoc, edit.range.start);
+			toBase = safeLspPositionToOffset(plugin.syncedDoc, edit.range.end);
+		} catch (err) {
+			console.error("[applyTextEdits] position conversion failed:", err, edit);
+			continue;
+		}
+		const fromResult = plugin.unsyncedChanges.mapPos(
+			fromBase,
+			1,
+			MapMode.TrackDel,
+		);
+		const toResult = plugin.unsyncedChanges.mapPos(
+			toBase,
+			-1,
+			MapMode.TrackDel,
+		);
+		if (fromResult == null || toResult == null) continue;
+		const insert =
+			typeof edit.newText === "string"
+				? edit.newText.replace(/\r\n/g, "\n")
+				: "";
+		changes.push({ from: fromResult, to: toResult, insert });
+	}
+	if (!changes.length) return false;
+	changes.sort((a, b) => a.from - b.from || a.to - b.to);
+	view.dispatch({ changes });
+	return true;
+}

--- a/src/cm/lsp/tooltipExtensions.ts
+++ b/src/cm/lsp/tooltipExtensions.ts
@@ -38,6 +38,7 @@ import type {
 	MarkupContent,
 } from "vscode-languageserver-types";
 import { getMode, getModeForPath, type Mode } from "../modelist";
+import type AcodeWorkspace from "./workspace";
 
 interface LspClientInternals {
 	config?: {
@@ -163,33 +164,30 @@ function interceptFileLinks(container: HTMLElement, view: EditorView): void {
 		event.preventDefault();
 		event.stopPropagation();
 
+		const plugin = LSPPlugin.get(view);
+		if (!plugin) return;
+		const workspace = plugin.client.workspace as AcodeWorkspace;
+		if (!workspace) return;
+
 		void (async () => {
 			try {
 				const match = /^(file:\/\/[^#]*)(?:#L?(\d+))?/.exec(href);
 				if (!match) return;
 				const [, rawUri, lineStr] = match;
 
-				const { resolveContentUriForFileUri } = await import(
-					"components/referencesPanel/utils"
-				);
-				const resolvedUri = resolveContentUriForFileUri(rawUri) ?? rawUri;
-
-				const openFile = (await import("lib/openFile")).default;
-				await openFile(resolvedUri, { render: true });
+				const targetView = await workspace.displayFile(rawUri);
+				if (!targetView) return;
 
 				if (lineStr) {
 					const line = Number.parseInt(lineStr, 10);
-					const { editor } = editorManager;
-					if (editor && Number.isFinite(line)) {
-						const doc = editor.state.doc;
-						if (line >= 1 && line <= doc.lines) {
-							const { from } = doc.line(line);
-							editor.dispatch({
-								selection: { anchor: from },
-								effects: EditorView.scrollIntoView(from, { y: "center" }),
-							});
-							editor.focus();
-						}
+					const doc = targetView.state.doc;
+					if (Number.isFinite(line) && line >= 1 && line <= doc.lines) {
+						const { from } = doc.line(line);
+						targetView.dispatch({
+							selection: { anchor: from },
+							effects: EditorView.scrollIntoView(from, { y: "center" }),
+						});
+						targetView.focus();
 					}
 				}
 			} catch (error) {

--- a/src/cm/lsp/tooltipExtensions.ts
+++ b/src/cm/lsp/tooltipExtensions.ts
@@ -151,6 +151,54 @@ function startPluginLanguageLoad(mode: Mode): Promise<Language | null> | null {
 	return load;
 }
 
+function interceptFileLinks(container: HTMLElement, view: EditorView): void {
+	container.addEventListener("click", (event) => {
+		const target = event.target as HTMLElement | null;
+		const anchor = target?.closest?.("a[href]") as HTMLAnchorElement | null;
+		if (!anchor) return;
+
+		const href = anchor.getAttribute("href");
+		if (!href || !href.startsWith("file://")) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		void (async () => {
+			try {
+				const match = /^(file:\/\/[^#]*)(?:#L?(\d+))?/.exec(href);
+				if (!match) return;
+				const [, rawUri, lineStr] = match;
+
+				const { resolveContentUriForFileUri } = await import(
+					"components/referencesPanel/utils"
+				);
+				const resolvedUri = resolveContentUriForFileUri(rawUri) ?? rawUri;
+
+				const openFile = (await import("lib/openFile")).default;
+				await openFile(resolvedUri, { render: true });
+
+				if (lineStr) {
+					const line = Number.parseInt(lineStr, 10);
+					const { editor } = editorManager;
+					if (editor && Number.isFinite(line)) {
+						const doc = editor.state.doc;
+						if (line >= 1 && line <= doc.lines) {
+							const { from } = doc.line(line);
+							editor.dispatch({
+								selection: { anchor: from },
+								effects: EditorView.scrollIntoView(from, { y: "center" }),
+							});
+							editor.focus();
+						}
+					}
+				}
+			} catch (error) {
+				console.error("[LSP:Tooltip] Failed to open file link:", href, error);
+			}
+		})();
+	});
+}
+
 export function resolveLspHoverHighlightLanguage(
 	language: string,
 ): Language | null {
@@ -384,6 +432,7 @@ function lspTooltipSource(
 				const dom = document.createElement("div");
 				dom.className = "cm-lsp-hover-tooltip cm-lsp-documentation";
 				dom.innerHTML = renderTooltipContent(plugin, result.contents);
+				interceptFileLinks(dom, view);
 				return { dom };
 			},
 			above: true,
@@ -575,6 +624,7 @@ function drawSignatureTooltip(
 			const docs = dom.appendChild(document.createElement("div"));
 			docs.className = "cm-lsp-signature-documentation cm-lsp-documentation";
 			docs.innerHTML = plugin.docToHTML(signature.documentation);
+			interceptFileLinks(docs, view);
 		}
 	}
 

--- a/src/cm/lsp/transport.ts
+++ b/src/cm/lsp/transport.ts
@@ -11,6 +11,10 @@ import type {
 	TransportHandle,
 	WebSocketTransportOptions,
 } from "./types";
+//new
+import { LSPPlugin } from "@codemirror/lsp-client";
+import type { TextEdit } from "vscode-languageserver-types";
+import { applyTextEdits } from "./textEditUtils";
 
 const DEFAULT_TIMEOUT = 5000;
 const RECONNECT_BASE_DELAY = 500;
@@ -157,6 +161,45 @@ function createWebSocketTransport(
 		dispatchToListeners(data);
 	}
 
+interface WorkspaceEditParam {
+	changes?: Record<string, TextEdit[]>;
+	documentChanges?: Array<{ textDocument: { uri: string }; edits: TextEdit[] }>;
+}
+
+function applyWorkspaceEditToContext(
+	edit: WorkspaceEditParam | undefined,
+	ctx: TransportContext,
+): { applied: boolean; failureReason?: string } {
+	if (!edit) return { applied: false, failureReason: "No edit provided" };
+	if (!ctx.view || !ctx.uri) {
+		return { applied: false, failureReason: "No active editor view for this document" };
+	}
+
+	const changesByUri: Record<string, TextEdit[]> =
+		edit.changes ??
+		Object.fromEntries(
+			(edit.documentChanges ?? [])
+				.filter((c): c is { textDocument: { uri: string }; edits: TextEdit[] } => "edits" in c)
+				.map((c) => [c.textDocument.uri, c.edits]),
+		);
+
+	const edits = changesByUri[ctx.uri];
+	if (!edits) {
+		return {
+			applied: false,
+			failureReason: `Edit targets ${Object.keys(changesByUri).join(", ") || "no files"}, which is not open here`,
+		};
+	}
+
+	const plugin = LSPPlugin.get(ctx.view);
+	if (!plugin) {
+		return { applied: false, failureReason: "LSP plugin not attached to view" };
+	}
+
+	const applied = applyTextEdits(plugin, ctx.view, edits);
+	return applied ? { applied: true } : { applied: false, failureReason: "Edit produced no changes" };
+}
+
 	function dispatchToListeners(data: string): void {
 		// Debugging aid while stabilising websocket transport
 		if (context?.debugWebSocket) {
@@ -196,6 +239,9 @@ function createWebSocketTransport(
 							: null;
 						break;
 					}
+					case "workspace/applyEdit":
+          	result = applyWorkspaceEditToContext(msg.params?.edit, context);
+          	break;
 					default:
 						handled = false;
 				}

--- a/src/cm/lsp/transport.ts
+++ b/src/cm/lsp/transport.ts
@@ -15,6 +15,7 @@ import type {
 import { LSPPlugin } from "@codemirror/lsp-client";
 import type { TextEdit } from "vscode-languageserver-types";
 import { applyTextEdits } from "./textEditUtils";
+import type AcodeWorkspace from "./workspace";
 
 const DEFAULT_TIMEOUT = 5000;
 const RECONNECT_BASE_DELAY = 500;
@@ -201,78 +202,107 @@ function applyWorkspaceEditToContext(
 }
 
 	function dispatchToListeners(data: string): void {
-		// Debugging aid while stabilising websocket transport
-		if (context?.debugWebSocket) {
-			console.debug(`[LSP:${server.id}] <=`, data);
-		}
+	// Debugging aid while stabilising websocket transport
+	if (context?.debugWebSocket) {
+		console.debug(`[LSP:${server.id}] <=`, data);
+	}
 
-		try {
-			const msg = JSON.parse(data);
-			if (msg && typeof msg.id !== "undefined") {
-				let handled = true;
-				let result: unknown = null;
-				switch (msg.method) {
-					case "window/workDoneProgress/create":
-					case "workspace/diagnostic/refresh":
-					case "client/registerCapability":
-					case "client/unregisterCapability":
-						break;
-					case "workspace/configuration":
-						result = Array.isArray(msg.params?.items)
-							? msg.params.items.map(
-									(item: { section?: unknown }) =>
-										resolveWorkspaceConfiguration(item?.section),
-								)
-							: [];
-						break;
-					case "workspace/workspaceFolders": {
-						const rootUri = context.rootUri;
-						result = rootUri
-							? [
-									{
-										uri: rootUri,
-										name:
-											rootUri.replace(/\/$/, "").split("/").pop() ||
-											rootUri,
-									},
-								]
-							: null;
-						break;
-					}
-					case "workspace/applyEdit":
-          	result = applyWorkspaceEditToContext(msg.params?.edit, context);
-          	break;
-					default:
-						handled = false;
-				}
-				if (!handled) {
-					notifyListeners(data);
-					return;
-				}
-				const response = JSON.stringify({
-					jsonrpc: "2.0",
-					id: msg.id,
-					result,
-				});
-				if (context?.debugWebSocket) {
-					console.debug(`[LSP:${server.id}] => (auto-response)`, response);
-				}
-				sendMessage(response);
-				if (msg.method === "workspace/diagnostic/refresh") {
-					notifyListeners(
-						JSON.stringify({
+	try {
+		const msg = JSON.parse(data);
+		if (msg && typeof msg.id !== "undefined") {
+			// workspace/applyEdit needs to await file-opening/edit-application,
+			// so it can't go through the synchronous switch below. Handle it
+			// separately and return immediately.
+			if (msg.method === "workspace/applyEdit") {
+				applyWorkspaceEditToContext(msg.params?.edit, context)
+					.then((result) => {
+						const response = JSON.stringify({
 							jsonrpc: "2.0",
-							method: msg.method,
-							params: msg.params ?? {},
-						}),
-					);
-				}
+							id: msg.id,
+							result,
+						});
+						if (context?.debugWebSocket) {
+							console.debug(`[LSP:${server.id}] => (auto-response)`, response);
+						}
+						sendMessage(response);
+					})
+					.catch((error) => {
+						console.error(`[LSP:${server.id}] workspace/applyEdit failed:`, error);
+						sendMessage(
+							JSON.stringify({
+								jsonrpc: "2.0",
+								id: msg.id,
+								result: {
+									applied: false,
+									failureReason: "Internal error applying edit",
+								},
+							}),
+						);
+					});
 				return;
 			}
-		} catch (_) {}
 
-		notifyListeners(data);
-	}
+			let handled = true;
+			let result: unknown = null;
+			switch (msg.method) {
+				case "window/workDoneProgress/create":
+				case "workspace/diagnostic/refresh":
+				case "client/registerCapability":
+				case "client/unregisterCapability":
+					break;
+				case "workspace/configuration":
+					result = Array.isArray(msg.params?.items)
+						? msg.params.items.map(
+								(item: { section?: unknown }) =>
+									resolveWorkspaceConfiguration(item?.section),
+							)
+						: [];
+					break;
+				case "workspace/workspaceFolders": {
+					const rootUri = context.rootUri;
+					result = rootUri
+						? [
+								{
+									uri: rootUri,
+									name:
+										rootUri.replace(/\/$/, "").split("/").pop() ||
+										rootUri,
+								},
+							]
+						: null;
+					break;
+				}
+				default:
+					handled = false;
+			}
+			if (!handled) {
+				notifyListeners(data);
+				return;
+			}
+			const response = JSON.stringify({
+				jsonrpc: "2.0",
+				id: msg.id,
+				result,
+			});
+			if (context?.debugWebSocket) {
+				console.debug(`[LSP:${server.id}] => (auto-response)`, response);
+			}
+			sendMessage(response);
+			if (msg.method === "workspace/diagnostic/refresh") {
+				notifyListeners(
+					JSON.stringify({
+						jsonrpc: "2.0",
+						method: msg.method,
+						params: msg.params ?? {},
+					}),
+				);
+			}
+			return;
+		}
+	} catch (_) {}
+
+	notifyListeners(data);
+}
 
 	function handleClose(event: CloseEvent): void {
 		connected = false;

--- a/src/cm/lsp/transport.ts
+++ b/src/cm/lsp/transport.ts
@@ -167,14 +167,11 @@ interface WorkspaceEditParam {
 	documentChanges?: Array<{ textDocument: { uri: string }; edits: TextEdit[] }>;
 }
 
-function applyWorkspaceEditToContext(
+async function applyWorkspaceEditToContext(
 	edit: WorkspaceEditParam | undefined,
 	ctx: TransportContext,
-): { applied: boolean; failureReason?: string } {
+): Promise<{ applied: boolean; failureReason?: string }> {
 	if (!edit) return { applied: false, failureReason: "No edit provided" };
-	if (!ctx.view || !ctx.uri) {
-		return { applied: false, failureReason: "No active editor view for this document" };
-	}
 
 	const changesByUri: Record<string, TextEdit[]> =
 		edit.changes ??
@@ -184,21 +181,64 @@ function applyWorkspaceEditToContext(
 				.map((c) => [c.textDocument.uri, c.edits]),
 		);
 
-	const edits = changesByUri[ctx.uri];
-	if (!edits) {
+	const uris = Object.keys(changesByUri);
+	if (!uris.length) {
+		return { applied: false, failureReason: "Edit contains no changes" };
+	}
+
+	const workspace = ctx.view
+		? (LSPPlugin.get(ctx.view)?.client.workspace as AcodeWorkspace | undefined)
+		: undefined;
+
+	if (!workspace) {
+		return { applied: false, failureReason: "No workspace available to apply edit" };
+	}
+
+	let appliedCount = 0;
+	const failures: string[] = [];
+
+	for (const uri of uris) {
+		const edits = changesByUri[uri];
+		if (!edits.length) continue;
+
+		let view = workspace.getFile(uri)?.getView();
+		if (!view) {
+			try {
+				view = await workspace.displayFile(uri);
+			} catch (error) {
+				failures.push(uri);
+				continue;
+			}
+		}
+		if (!view) {
+			failures.push(uri);
+			continue;
+		}
+
+		const plugin = LSPPlugin.get(view);
+		if (!plugin) {
+			failures.push(uri);
+			continue;
+		}
+
+		const applied = applyTextEdits(plugin, view, edits);
+		if (applied) appliedCount++;
+		else failures.push(uri);
+	}
+
+	if (appliedCount === 0) {
 		return {
 			applied: false,
-			failureReason: `Edit targets ${Object.keys(changesByUri).join(", ") || "no files"}, which is not open here`,
+			failureReason: `Could not apply edit to: ${failures.join(", ")}`,
 		};
 	}
-
-	const plugin = LSPPlugin.get(ctx.view);
-	if (!plugin) {
-		return { applied: false, failureReason: "LSP plugin not attached to view" };
+	if (failures.length) {
+		return {
+			applied: true,
+			failureReason: `Applied to ${appliedCount} file(s); failed: ${failures.join(", ")}`,
+		};
 	}
-
-	const applied = applyTextEdits(plugin, ctx.view, edits);
-	return applied ? { applied: true } : { applied: false, failureReason: "Edit produced no changes" };
+	return { applied: true };
 }
 
 	function dispatchToListeners(data: string): void {

--- a/src/components/referencesPanel/utils.js
+++ b/src/components/referencesPanel/utils.js
@@ -187,18 +187,21 @@ const CONTENT_AUTHORITY_HANDLERS = {
 			return `${base}/${remainder}`;
 		},
 	},
-	termux: {
+	"foxdebug.acode": {
 		docIdToPath(docId) {
-			let path = docId.replace(/:+$/, "");
-			try {
-				path = decodeURIComponent(path);
-			} catch {
-				// already decoded
+			let normalized = docId.replace(/:+$/, "");
+			if (!normalized) return null;
+			if (normalized.startsWith("raw:/")) {
+				normalized = normalized.slice(4);
+			} else if (normalized.startsWith("raw:")) {
+				normalized = normalized.slice(4);
 			}
-			return path.startsWith("/") ? path : null;
+			return normalized.startsWith("/") ? normalized : null;
 		},
 	},
 };
+CONTENT_AUTHORITY_HANDLERS["foxdebug.acodefree"] =
+	CONTENT_AUTHORITY_HANDLERS["foxdebug.acode"];
 
 function getContentAuthorityId(contentUri) {
 	const match = /^content:\/\/com\.((?![:<>"/\\|?*]).*?)\.documents\//.exec(

--- a/src/components/referencesPanel/utils.js
+++ b/src/components/referencesPanel/utils.js
@@ -10,6 +10,7 @@ import {
 import helpers from "utils/helpers";
 
 import Uri from "utils/Uri";
+import Url from "utils/Url";
 import { addedFolder } from "lib/openFolder";
 import toast from "components/toast";
 
@@ -172,6 +173,40 @@ function docIdToRealPath(docId) {
 	return remainder ? `${base}/${remainder}` : base;
 }
 
+const CONTENT_AUTHORITY_HANDLERS = {
+	"android.externalstorage": {
+		docIdToPath(docId) {
+			const trimmed = docId.replace(/:+$/, "");
+			const separator = trimmed.indexOf(":");
+			if (separator === -1) return null;
+			const volume = trimmed.slice(0, separator);
+			const remainder = trimmed.slice(separator + 1);
+			if (!remainder) return null;
+			const base =
+				volume === "primary" ? "/storage/emulated/0" : `/storage/${volume}`;
+			return `${base}/${remainder}`;
+		},
+	},
+	termux: {
+		docIdToPath(docId) {
+			let path = docId.replace(/:+$/, "");
+			try {
+				path = decodeURIComponent(path);
+			} catch {
+				// already decoded
+			}
+			return path.startsWith("/") ? path : null;
+		},
+	},
+};
+
+function getContentAuthorityId(contentUri) {
+	const match = /^content:\/\/com\.((?![:<>"/\\|?*]).*?)\.documents\//.exec(
+		contentUri,
+	);
+	return match?.[1] ?? null;
+}
+
 /**
  * LSP servers hand back plain file:// uris. Acode tracks externally-added
  * files by their original content:// SAF uri, so an lsp uri never matches
@@ -185,27 +220,54 @@ export function resolveContentUriForFileUri(fileUri) {
 	const targetPath = decodeURIComponent(fileUri.slice("file://".length));
 
 	for (const folder of addedFolder) {
-		if (!folder?.url?.startsWith("content:")) continue;
+		const rootUrl = folder?.url;
+		if (!rootUrl) continue;
 
-		let parsed;
-		try {
-			parsed = Uri.parse(folder.url);
-		} catch {
+		if (rootUrl.startsWith("content:")) {
+			let parsed;
+			try {
+				parsed = Uri.parse(rootUrl);
+			} catch {
+				continue;
+			}
+			const authorityId = getContentAuthorityId(parsed.rootUri ?? rootUrl);
+			const handler = authorityId && CONTENT_AUTHORITY_HANDLERS[authorityId];
+			if (!handler) continue;
+
+			const rootPath = handler.docIdToPath(parsed.docId);
+			if (!rootPath) continue;
+
+			if (targetPath === rootPath) {
+				return Uri.format(parsed.rootUri, parsed.docId);
+			}
+			if (targetPath.startsWith(`${rootPath}/`)) {
+				const suffix = targetPath.slice(rootPath.length); // leading "/"
+				const childDocId = parsed.docId.endsWith("/")
+					? parsed.docId.slice(0, -1) + suffix
+					: parsed.docId + suffix;
+				return Uri.format(parsed.rootUri, childDocId);
+			}
 			continue;
 		}
 
-		const rootPath = docIdToRealPath(parsed.docId);
-		if (!rootPath) continue;
+		if (rootUrl.startsWith("sftp:")) {
+			let rootPath;
+			try {
+				rootPath = Url.pathname(rootUrl).replace(/\/+$/, "");
+			} catch {
+				continue;
+			}
+			if (!rootPath) continue;
 
-		if (targetPath === rootPath) {
-			return Uri.format(parsed.rootUri, parsed.docId);
-		}
-		if (targetPath.startsWith(`${rootPath}/`)) {
-			const suffix = targetPath.slice(rootPath.length); // leading "/"
-			const childDocId = parsed.docId.endsWith("/")
-				? parsed.docId.slice(0, -1) + suffix
-				: parsed.docId + suffix;
-			return Uri.format(parsed.rootUri, childDocId);
+			if (targetPath === rootPath) return rootUrl;
+			if (targetPath.startsWith(`${rootPath}/`)) {
+				const suffix = targetPath.slice(rootPath.length);
+				const base = rootUrl.slice(
+					0,
+					rootUrl.indexOf(rootPath) + rootPath.length,
+				);
+				return base + suffix;
+			}
 		}
 	}
 

--- a/src/components/referencesPanel/utils.js
+++ b/src/components/referencesPanel/utils.js
@@ -9,6 +9,10 @@ import {
 } from "utils/codeHighlight";
 import helpers from "utils/helpers";
 
+import Uri from "utils/Uri";
+import { addedFolder } from "lib/openFolder";
+import toast from "components/toast";
+
 export { clearHighlightCache, sanitize };
 
 export function getFilename(uri) {
@@ -111,7 +115,22 @@ export async function navigateToReference(ref) {
 	Sidebar.hide();
 
 	try {
-		await openFile(ref.uri, { render: true });
+		let targetUri = ref.uri;
+
+		if (
+			targetUri.startsWith("file:///") &&
+			!editorManager.getFile(targetUri, "uri")
+		) {
+			const contentUri = resolveContentUriForFileUri(targetUri);
+			if (contentUri) {
+				targetUri = contentUri;
+			} else {
+				toast("Definition unreachable");
+				return;
+			}
+		}
+
+		await openFile(targetUri, { render: true });
 		const { editor } = editorManager;
 		if (!editor) return;
 
@@ -142,4 +161,53 @@ export function getReferencesStats(references) {
 		refCount,
 		text: `${refCount} reference${refCount !== 1 ? "s" : ""} in ${fileCount} file${fileCount !== 1 ? "s" : ""}`,
 	};
+}
+
+function docIdToRealPath(docId) {
+	const sepIndex = docId.indexOf(":");
+	if (sepIndex === -1) return null;
+	const volume = docId.slice(0, sepIndex);
+	const remainder = docId.slice(sepIndex + 1);
+	const base = volume === "primary" ? "/storage/emulated/0" : `/storage/${volume}`;
+	return remainder ? `${base}/${remainder}` : base;
+}
+
+/**
+ * LSP servers hand back plain file:// uris. Acode tracks externally-added
+ * files by their original content:// SAF uri, so an lsp uri never matches
+ * an open tab directly. Resolve it against the currently added folders
+ * (the only external files Acode can reach without a fresh SAF prompt)
+ * and rebuild the real content:// uri, same docId scheme openFolder.js
+ * already relies on elsewhere in this codebase.
+ */
+export function resolveContentUriForFileUri(fileUri) {
+	if (!fileUri?.startsWith("file:///")) return null;
+	const targetPath = decodeURIComponent(fileUri.slice("file://".length));
+
+	for (const folder of addedFolder) {
+		if (!folder?.url?.startsWith("content:")) continue;
+
+		let parsed;
+		try {
+			parsed = Uri.parse(folder.url);
+		} catch {
+			continue;
+		}
+
+		const rootPath = docIdToRealPath(parsed.docId);
+		if (!rootPath) continue;
+
+		if (targetPath === rootPath) {
+			return Uri.format(parsed.rootUri, parsed.docId);
+		}
+		if (targetPath.startsWith(`${rootPath}/`)) {
+			const suffix = targetPath.slice(rootPath.length); // leading "/"
+			const childDocId = parsed.docId.endsWith("/")
+				? parsed.docId.slice(0, -1) + suffix
+				: parsed.docId + suffix;
+			return Uri.format(parsed.rootUri, childDocId);
+		}
+	}
+
+	return null;
 }

--- a/src/components/referencesPanel/utils.js
+++ b/src/components/referencesPanel/utils.js
@@ -1,18 +1,17 @@
 import { EditorView } from "@codemirror/view";
 import Sidebar from "components/sidebar";
+import toast from "components/toast";
 import DOMPurify from "dompurify";
 import openFile from "lib/openFile";
+import { addedFolder } from "lib/openFolder";
 import {
 	clearHighlightCache,
 	highlightLine,
 	sanitize,
 } from "utils/codeHighlight";
 import helpers from "utils/helpers";
-
 import Uri from "utils/Uri";
 import Url from "utils/Url";
-import { addedFolder } from "lib/openFolder";
-import toast from "components/toast";
 
 export { clearHighlightCache, sanitize };
 
@@ -169,7 +168,8 @@ function docIdToRealPath(docId) {
 	if (sepIndex === -1) return null;
 	const volume = docId.slice(0, sepIndex);
 	const remainder = docId.slice(sepIndex + 1);
-	const base = volume === "primary" ? "/storage/emulated/0" : `/storage/${volume}`;
+	const base =
+		volume === "primary" ? "/storage/emulated/0" : `/storage/${volume}`;
 	return remainder ? `${base}/${remainder}` : base;
 }
 

--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -98,6 +98,7 @@ import {
 	getSystemConfiguration,
 	HARDKEYBOARDHIDDEN_NO,
 } from "./systemConfiguration";
+import Url from "utils/Url";
 
 /**
  * Represents an editor manager that handles multiple files and provides various editor configurations and event listeners.
@@ -1512,15 +1513,37 @@ async function EditorManager($header, $body) {
 	}
 
 	function resolveRootUriForContext(context = {}) {
-		const uri = context.uri || context.file?.uri;
-		if (!uri) return null;
-		for (const folder of addedFolder) {
-			const base = typeof folder?.url === "string" ? folder.url : "";
-			if (!base) continue;
-			if (uri.startsWith(base)) return base;
+	const uri = context.uri || context.file?.uri;
+	if (!uri) return null;
+
+	for (const folder of addedFolder) {
+		const base = typeof folder?.url === "string" ? folder.url : "";
+		if (!base) continue;
+
+		// Plain schemes (content://, file://) are stable strings with no
+		// variable auth/port formatting — a literal prefix check is fine.
+		if (uri.startsWith(base)) return base;
+
+		// sftp:// can carry credential/port formatting that legitimately
+		// differs between when a folder was added and when an individual
+		// file's own uri gets built later, even though both point at the
+		// same remote path. Compare the actual remote paths instead of
+		// the raw connection strings.
+		if (uri.startsWith("sftp:") && base.startsWith("sftp:")) {
+			try {
+				const uriPath = Url.pathname(uri);
+				const basePath = Url.pathname(base).replace(/\/+$/, "");
+				if (uriPath === basePath || uriPath.startsWith(`${basePath}/`)) {
+					return base;
+				}
+			} catch (error) {
+				// malformed url, try the next folder
+			}
 		}
-		return uri;
 	}
+
+	return uri;
+}
 
 	function detachActiveLsp(pane = getActivePane(), { invalidate = true } = {}) {
 		if (!pane) return;

--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -89,6 +89,7 @@ import ScrollBar from "components/scrollbar";
 import SideButton, { sideButtonContainer } from "components/sideButton";
 import keyboardHandler, { keydownState } from "handlers/keyboard";
 import { animate } from "motion";
+import Url from "utils/Url";
 import config from "./config";
 import EditorFile from "./editorFile";
 import openFile from "./openFile";
@@ -98,7 +99,6 @@ import {
 	getSystemConfiguration,
 	HARDKEYBOARDHIDDEN_NO,
 } from "./systemConfiguration";
-import Url from "utils/Url";
 
 /**
  * Represents an editor manager that handles multiple files and provides various editor configurations and event listeners.
@@ -142,21 +142,25 @@ async function EditorManager($header, $body) {
 	let historyStack = [];
 	let historyIndex = -1;
 	let isNavigatingHistory = false;
-	
+
 	async function resolveDisplayUri(targetUri) {
-	if (!targetUri) return null;
-	const decodedUri = decodeURIComponent(targetUri);
-	if (!decodedUri.startsWith("file:///")) return decodedUri;
-	try {
-		const { resolveContentUriForFileUri } = await import(
-			"components/referencesPanel/utils"
-		);
-		return resolveContentUriForFileUri(decodedUri) ?? decodedUri;
-	} catch (error) {
-		console.warn("[LSP] Failed to resolve uri for display", decodedUri, error);
-		return decodedUri;
+		if (!targetUri) return null;
+		const decodedUri = decodeURIComponent(targetUri);
+		if (!decodedUri.startsWith("file:///")) return decodedUri;
+		try {
+			const { resolveContentUriForFileUri } = await import(
+				"components/referencesPanel/utils"
+			);
+			return resolveContentUriForFileUri(decodedUri) ?? decodedUri;
+		} catch (error) {
+			console.warn(
+				"[LSP] Failed to resolve uri for display",
+				decodedUri,
+				error,
+			);
+			return decodedUri;
+		}
 	}
-}
 
 	function warnRecoverable(message, error, key) {
 		if (key) {
@@ -1528,37 +1532,37 @@ async function EditorManager($header, $body) {
 	}
 
 	function resolveRootUriForContext(context = {}) {
-	const uri = context.uri || context.file?.uri;
-	if (!uri) return null;
+		const uri = context.uri || context.file?.uri;
+		if (!uri) return null;
 
-	for (const folder of addedFolder) {
-		const base = typeof folder?.url === "string" ? folder.url : "";
-		if (!base) continue;
+		for (const folder of addedFolder) {
+			const base = typeof folder?.url === "string" ? folder.url : "";
+			if (!base) continue;
 
-		// Plain schemes (content://, file://) are stable strings with no
-		// variable auth/port formatting — a literal prefix check is fine.
-		if (uri.startsWith(base)) return base;
+			// Plain schemes (content://, file://) are stable strings with no
+			// variable auth/port formatting — a literal prefix check is fine.
+			if (uri.startsWith(base)) return base;
 
-		// sftp:// can carry credential/port formatting that legitimately
-		// differs between when a folder was added and when an individual
-		// file's own uri gets built later, even though both point at the
-		// same remote path. Compare the actual remote paths instead of
-		// the raw connection strings.
-		if (uri.startsWith("sftp:") && base.startsWith("sftp:")) {
-			try {
-				const uriPath = Url.pathname(uri);
-				const basePath = Url.pathname(base).replace(/\/+$/, "");
-				if (uriPath === basePath || uriPath.startsWith(`${basePath}/`)) {
-					return base;
+			// sftp:// can carry credential/port formatting that legitimately
+			// differs between when a folder was added and when an individual
+			// file's own uri gets built later, even though both point at the
+			// same remote path. Compare the actual remote paths instead of
+			// the raw connection strings.
+			if (uri.startsWith("sftp:") && base.startsWith("sftp:")) {
+				try {
+					const uriPath = Url.pathname(uri);
+					const basePath = Url.pathname(base).replace(/\/+$/, "");
+					if (uriPath === basePath || uriPath.startsWith(`${basePath}/`)) {
+						return base;
+					}
+				} catch (error) {
+					// malformed url, try the next folder
 				}
-			} catch (error) {
-				// malformed url, try the next folder
 			}
 		}
-	}
 
-	return uri;
-}
+		return uri;
+	}
 
 	function detachActiveLsp(pane = getActivePane(), { invalidate = true } = {}) {
 		if (!pane) return;
@@ -3349,45 +3353,45 @@ async function EditorManager($header, $body) {
 			})();
 		},
 		displayFile: async (targetUri) => {
-	const resolvedUri = await resolveDisplayUri(targetUri);
-	if (!resolvedUri) return null;
-	const existing = manager.getFile(resolvedUri, "uri");
-	if (existing?.type === "editor") {
-		existing.makeActive();
-		return editor;
-	}
-	try {
-		await openFile(resolvedUri, { render: true });
-		const opened = manager.getFile(resolvedUri, "uri");
-		if (opened?.type === "editor") {
-			opened.makeActive();
-			return editor;
-		}
-	} catch (error) {
-		console.error("[LSP] Failed to open file", resolvedUri, error);
-	}
-	return null;
-},
-openFile: async (targetUri) => {
-	const resolvedUri = await resolveDisplayUri(targetUri);
-	if (!resolvedUri) return null;
-	const existing = manager.getFile(resolvedUri, "uri");
-	if (existing?.type === "editor") {
-		existing.makeActive();
-		return editor;
-	}
-	try {
-		await openFile(resolvedUri, { render: true });
-		const opened = manager.getFile(resolvedUri, "uri");
-		if (opened?.type === "editor") {
-			opened.makeActive();
-			return editor;
-		}
-	} catch (error) {
-		console.error("[LSP] Failed to open file", resolvedUri, error);
-	}
-	return null;
-},
+			const resolvedUri = await resolveDisplayUri(targetUri);
+			if (!resolvedUri) return null;
+			const existing = manager.getFile(resolvedUri, "uri");
+			if (existing?.type === "editor") {
+				existing.makeActive();
+				return editor;
+			}
+			try {
+				await openFile(resolvedUri, { render: true });
+				const opened = manager.getFile(resolvedUri, "uri");
+				if (opened?.type === "editor") {
+					opened.makeActive();
+					return editor;
+				}
+			} catch (error) {
+				console.error("[LSP] Failed to open file", resolvedUri, error);
+			}
+			return null;
+		},
+		openFile: async (targetUri) => {
+			const resolvedUri = await resolveDisplayUri(targetUri);
+			if (!resolvedUri) return null;
+			const existing = manager.getFile(resolvedUri, "uri");
+			if (existing?.type === "editor") {
+				existing.makeActive();
+				return editor;
+			}
+			try {
+				await openFile(resolvedUri, { render: true });
+				const opened = manager.getFile(resolvedUri, "uri");
+				if (opened?.type === "editor") {
+					opened.makeActive();
+					return editor;
+				}
+			} catch (error) {
+				console.error("[LSP] Failed to open file", resolvedUri, error);
+			}
+			return null;
+		},
 		resolveLanguageId: (uri) => {
 			if (!uri) return "plaintext";
 			try {

--- a/src/lib/editorManager.js
+++ b/src/lib/editorManager.js
@@ -142,6 +142,21 @@ async function EditorManager($header, $body) {
 	let historyStack = [];
 	let historyIndex = -1;
 	let isNavigatingHistory = false;
+	
+	async function resolveDisplayUri(targetUri) {
+	if (!targetUri) return null;
+	const decodedUri = decodeURIComponent(targetUri);
+	if (!decodedUri.startsWith("file:///")) return decodedUri;
+	try {
+		const { resolveContentUriForFileUri } = await import(
+			"components/referencesPanel/utils"
+		);
+		return resolveContentUriForFileUri(decodedUri) ?? decodedUri;
+	} catch (error) {
+		console.warn("[LSP] Failed to resolve uri for display", decodedUri, error);
+		return decodedUri;
+	}
+}
 
 	function warnRecoverable(message, error, key) {
 		if (key) {
@@ -3334,47 +3349,45 @@ async function EditorManager($header, $body) {
 			})();
 		},
 		displayFile: async (targetUri) => {
-			if (!targetUri) return null;
-			// Decode URI components (e.g., %40 -> @) since LSP returns encoded URIs
-			const decodedUri = decodeURIComponent(targetUri);
-			const existing = manager.getFile(decodedUri, "uri");
-			if (existing?.type === "editor") {
-				existing.makeActive();
-				return editor;
-			}
-			try {
-				await openFile(decodedUri, { render: true });
-				const opened = manager.getFile(decodedUri, "uri");
-				if (opened?.type === "editor") {
-					opened.makeActive();
-					return editor;
-				}
-			} catch (error) {
-				console.error("[LSP] Failed to open file", decodedUri, error);
-			}
-			return null;
-		},
-		openFile: async (targetUri) => {
-			if (!targetUri) return null;
-			// Decode URI components (e.g., %40 -> @)
-			const decodedUri = decodeURIComponent(targetUri);
-			const existing = manager.getFile(decodedUri, "uri");
-			if (existing?.type === "editor") {
-				existing.makeActive();
-				return editor;
-			}
-			try {
-				await openFile(decodedUri, { render: true });
-				const opened = manager.getFile(decodedUri, "uri");
-				if (opened?.type === "editor") {
-					opened.makeActive();
-					return editor;
-				}
-			} catch (error) {
-				console.error("[LSP] Failed to open file", decodedUri, error);
-			}
-			return null;
-		},
+	const resolvedUri = await resolveDisplayUri(targetUri);
+	if (!resolvedUri) return null;
+	const existing = manager.getFile(resolvedUri, "uri");
+	if (existing?.type === "editor") {
+		existing.makeActive();
+		return editor;
+	}
+	try {
+		await openFile(resolvedUri, { render: true });
+		const opened = manager.getFile(resolvedUri, "uri");
+		if (opened?.type === "editor") {
+			opened.makeActive();
+			return editor;
+		}
+	} catch (error) {
+		console.error("[LSP] Failed to open file", resolvedUri, error);
+	}
+	return null;
+},
+openFile: async (targetUri) => {
+	const resolvedUri = await resolveDisplayUri(targetUri);
+	if (!resolvedUri) return null;
+	const existing = manager.getFile(resolvedUri, "uri");
+	if (existing?.type === "editor") {
+		existing.makeActive();
+		return editor;
+	}
+	try {
+		await openFile(resolvedUri, { render: true });
+		const opened = manager.getFile(resolvedUri, "uri");
+		if (opened?.type === "editor") {
+			opened.makeActive();
+			return editor;
+		}
+	} catch (error) {
+		console.error("[LSP] Failed to open file", resolvedUri, error);
+	}
+	return null;
+},
 		resolveLanguageId: (uri) => {
 			if (!uri) return "plaintext";
 			try {

--- a/src/lib/selectionMenu.js
+++ b/src/lib/selectionMenu.js
@@ -77,11 +77,11 @@ const showLspMenu = async () => {
 			run: lsp.findAllReferences,
 		},
 		capabilities.renameProvider && {
-    	value: "rename",
-    	text: "Rename Symbol",
-    	icon: "edit",
-    	run: lsp.renameSymbol,
-    },
+			value: "rename",
+			text: "Rename Symbol",
+			icon: "edit",
+			run: lsp.renameSymbol,
+		},
 		lsp.supportsCodeActions(editor) && {
 			value: "codeActions",
 			text: "Code Actions",
@@ -134,11 +134,11 @@ export default function selectionMenu() {
 			"all",
 		),
 		item(
-	() => showLspMenu(),
-	<span className="icon lightbulb" title="LSP Actions"></span>,
-	"all",
-	true,
-),
+			() => showLspMenu(),
+			<span className="icon lightbulb" title="LSP Actions"></span>,
+			"all",
+			true,
+		),
 		...items,
 	].filter(Boolean);
 }
@@ -161,4 +161,3 @@ selectionMenu.exec = (command) => {
 function item(onclick, text, mode = "all", readOnly = false) {
 	return { onclick, text, mode, readOnly };
 }
-

--- a/src/lib/selectionMenu.js
+++ b/src/lib/selectionMenu.js
@@ -76,6 +76,12 @@ const showLspMenu = async () => {
 			icon: "linkinsert_link",
 			run: lsp.findAllReferences,
 		},
+		capabilities.renameProvider && {
+    	value: "rename",
+    	text: "Rename Symbol",
+    	icon: "edit",
+    	run: lsp.renameSymbol,
+    },
 		lsp.supportsCodeActions(editor) && {
 			value: "codeActions",
 			text: "Code Actions",

--- a/src/lib/selectionMenu.js
+++ b/src/lib/selectionMenu.js
@@ -1,5 +1,18 @@
 import appSettings from "lib/settings";
 
+function suppressResidualTouch(duration = 350) {
+	const swallow = (event) => {
+		event.stopPropagation();
+		event.preventDefault();
+	};
+	document.addEventListener("click", swallow, true);
+	document.addEventListener("pointerup", swallow, true);
+	setTimeout(() => {
+		document.removeEventListener("click", swallow, true);
+		document.removeEventListener("pointerup", swallow, true);
+	}, duration);
+}
+
 const exec = (command) => {
 	const { editor } = editorManager;
 	editor.execCommand(command);
@@ -12,18 +25,76 @@ const exec = (command) => {
 	editor.focus();
 };
 
-const showCodeActions = async () => {
+const showLspMenu = async () => {
+	suppressResidualTouch();
+
 	const { editor } = editorManager;
 	if (!editor) return;
 
+	let lsp;
 	try {
-		const { showCodeActionsMenu, supportsCodeActions } = await import("cm/lsp");
-		if (supportsCodeActions(editor)) {
-			await showCodeActionsMenu(editor);
-		}
+		lsp = await import("cm/lsp");
 	} catch (error) {
-		console.warn("[SelectionMenu] Code actions not available:", error);
+		console.warn("[SelectionMenu] LSP module not available:", error);
+		return;
 	}
+
+	const { LSPPlugin } = await import("@codemirror/lsp-client");
+	const plugin = LSPPlugin.get(editor);
+	if (!plugin) return;
+
+	const capabilities = plugin.client.serverCapabilities || {};
+
+	const actions = [
+		capabilities.definitionProvider && {
+			value: "definition",
+			text: "Go to Definition",
+			icon: "keyboard_arrow_right",
+			run: lsp.goToDefinition,
+		},
+		capabilities.declarationProvider && {
+			value: "declaration",
+			text: "Go to Declaration",
+			icon: "keyboard_arrow_right",
+			run: lsp.goToDeclaration,
+		},
+		capabilities.implementationProvider && {
+			value: "implementation",
+			text: "Go to Implementation",
+			icon: "keyboard_arrow_right",
+			run: lsp.goToImplementation,
+		},
+		capabilities.typeDefinitionProvider && {
+			value: "typeDefinition",
+			text: "Go to Type Definition",
+			icon: "keyboard_arrow_right",
+			run: lsp.goToTypeDefinition,
+		},
+		capabilities.referencesProvider && {
+			value: "references",
+			text: "Find References",
+			icon: "linkinsert_link",
+			run: lsp.findAllReferences,
+		},
+		lsp.supportsCodeActions(editor) && {
+			value: "codeActions",
+			text: "Code Actions",
+			icon: "lightbulb",
+			run: lsp.showCodeActionsMenu,
+		},
+	].filter(Boolean);
+
+	if (actions.length === 0) return;
+
+	// Skip the picker entirely if there's only one thing to offer
+	if (actions.length === 1) {
+		await actions[0].run(editor);
+		return;
+	}
+	const { default: select } = await import("dialogs/select");
+	const chosen = await select("LSP Actions", actions).catch(() => null);
+	const action = actions.find((a) => a.value === chosen);
+	if (action) await action.run(editor);
 };
 
 const items = [];
@@ -57,11 +128,11 @@ export default function selectionMenu() {
 			"all",
 		),
 		item(
-			() => showCodeActions(),
-			<span className="icon lightbulb" title="Code Actions"></span>,
-			"all",
-			true,
-		),
+	() => showLspMenu(),
+	<span className="icon lightbulb" title="LSP Actions"></span>,
+	"all",
+	true,
+),
 		...items,
 	].filter(Boolean);
 }
@@ -84,3 +155,4 @@ selectionMenu.exec = (command) => {
 function item(onclick, text, mode = "all", readOnly = false) {
 	return { onclick, text, mode, readOnly };
 }
+

--- a/src/settings/lspSettings.js
+++ b/src/settings/lspSettings.js
@@ -3,10 +3,10 @@ import serverRegistry from "cm/lsp/serverRegistry";
 import { builtinServers } from "cm/lsp/servers";
 import settingsPage from "components/settingsPage";
 import toast from "components/toast";
+import multiPrompt from "dialogs/multiPrompt";
 import prompt from "dialogs/prompt";
 import select from "dialogs/select";
 import appSettings from "lib/settings";
-import multiPrompt from "dialogs/multiPrompt";
 import {
 	getServerOverride,
 	isCustomServer,
@@ -296,7 +296,7 @@ export default function lspSettings() {
 			return;
 		}
 
-			if (key === "add_custom_server") {
+		if (key === "add_custom_server") {
 			try {
 				const USE_WS = true; // default transport; false = STDIO
 
@@ -435,8 +435,7 @@ export default function lspSettings() {
 						defaultCheckCommand,
 						"text",
 						{
-							placeholder:
-								defaultCheckCommand || "which my-language-server",
+							placeholder: defaultCheckCommand || "which my-language-server",
 						},
 					);
 					if (checkCommand === null) return;
@@ -478,7 +477,6 @@ export default function lspSettings() {
 			}
 			return;
 		}
-
 
 		if (key.startsWith("server:")) {
 			const id = key.split(":")[1];

--- a/src/settings/lspSettings.js
+++ b/src/settings/lspSettings.js
@@ -6,6 +6,7 @@ import toast from "components/toast";
 import prompt from "dialogs/prompt";
 import select from "dialogs/select";
 import appSettings from "lib/settings";
+import multiPrompt from "dialogs/multiPrompt";
 import {
 	getServerOverride,
 	isCustomServer,
@@ -295,123 +296,160 @@ export default function lspSettings() {
 			return;
 		}
 
-		if (key === "add_custom_server") {
+			if (key === "add_custom_server") {
 			try {
-				const idInput = await prompt(strings["lsp-server-id"], "", "text");
-				if (idInput === null) return;
+				const USE_WS = true; // default transport; false = STDIO
 
-				const serverId = normalizeServerId(idInput);
+				const result = await multiPrompt(strings["lsp-add-custom-server"], [
+					{
+						id: "serverId",
+						placeholder: strings["lsp-server-id"],
+						type: "text",
+						required: true,
+						value: "",
+					},
+					{
+						id: "label",
+						placeholder: strings["lsp-server-label"],
+						type: "text",
+						value: "",
+					},
+					{
+						id: "languages",
+						placeholder: strings["lsp-language-ids"],
+						type: "text",
+						required: true,
+						value: "",
+					},
+					[
+						"Transport: ",
+						{
+							id: "useWebSocket",
+							placeholder: "WebSocket",
+							name: "transportType",
+							type: "radio",
+							value: USE_WS,
+							onchange() {
+								if (!!this.value) {
+									this.prompt.$body.get("#websocketUrl").hidden = false;
+									this.prompt.$body.get("#binaryCommand").hidden = true;
+									this.prompt.$body.get("#binaryArgs").hidden = true;
+									this.prompt.$body.get("#binaryCommand").value = "";
+								}
+							},
+						},
+						{
+							id: "useStdio",
+							placeholder: "STDIO",
+							name: "transportType",
+							type: "radio",
+							value: !USE_WS,
+							onchange() {
+								if (!!this.value) {
+									this.prompt.$body.get("#websocketUrl").hidden = true;
+									this.prompt.$body.get("#websocketUrl").value = "";
+									this.prompt.$body.get("#binaryCommand").hidden = false;
+									this.prompt.$body.get("#binaryArgs").hidden = false;
+								}
+							},
+						},
+					],
+					{
+						id: "websocketUrl",
+						placeholder: "ws://127.0.0.1:3000/",
+						type: "text",
+						value: "ws://127.0.0.1:3000/",
+						hidden: !USE_WS,
+					},
+					{
+						id: "binaryCommand",
+						placeholder: strings["lsp-binary-command"],
+						type: "text",
+						hidden: USE_WS,
+						value: "",
+					},
+					{
+						id: "binaryArgs",
+						placeholder: strings["lsp-binary-args"],
+						type: "textarea",
+						hidden: USE_WS,
+						value: "[]",
+					},
+				]);
+
+				if (!result) return; // user cancelled
+
+				const serverId = normalizeServerId(result.serverId);
 				if (!serverId) {
 					toast(strings["lsp-error-server-id-required"]);
 					return;
 				}
 
-				const label = await prompt(
-					strings["lsp-server-label"],
-					serverId,
-					"text",
-				);
-				if (label === null) return;
-
-				const languageInput = await prompt(
-					strings["lsp-language-ids"],
-					"",
-					"text",
-				);
-				if (languageInput === null) return;
-				const languages = normalizeLanguages(languageInput);
+				const label = result.label || serverId;
+				const languages = normalizeLanguages(result.languages);
 				if (!languages.length) {
 					toast(strings["lsp-error-language-id-required"]);
 					return;
 				}
 
-				const transportKind = await select(
-					strings.type || "Type",
-					getTransportMethods(),
-				);
-				if (!transportKind) return;
-
 				let transport;
 				let launcher;
 
-				if (transportKind === "websocket") {
-					const websocketUrlInput = await prompt(
-						strings["lsp-websocket-url"] || "WebSocket URL",
-						"ws://127.0.0.1:3000/",
-						"text",
-						{
-							test: (value) => {
-								try {
-									parseWebSocketUrl(value);
-									return true;
-								} catch {
-									return false;
-								}
-							},
-						},
-					);
-					if (websocketUrlInput === null) return;
-
+				if (result.useWebSocket) {
+					const url = String(result.websocketUrl || "").trim();
+					if (!url) {
+						toast(
+							strings["lsp-error-websocket-url-required"] ||
+								"WebSocket URL is required",
+						);
+						return;
+					}
 					transport = {
 						kind: "websocket",
-						url: parseWebSocketUrl(websocketUrlInput),
+						url: parseWebSocketUrl(url),
 					};
 				} else {
-					const binaryCommand = await prompt(
-						strings["lsp-binary-command"],
-						"",
-						"text",
-					);
-					if (binaryCommand === null) return;
-					if (!String(binaryCommand).trim()) {
+					const binaryCommand = String(result.binaryCommand || "").trim();
+					if (!binaryCommand) {
 						toast(strings["lsp-error-binary-command-required"]);
 						return;
 					}
 
-					const argsInput = await prompt(
-						strings["lsp-binary-args"],
-						"[]",
-						"textarea",
-						{
-							test: (value) => {
-								try {
-									parseArgsInput(value);
-									return true;
-								} catch {
-									return false;
-								}
-							},
-						},
-					);
-					if (argsInput === null) return;
+					let parsedArgs;
+					try {
+						parsedArgs = parseArgsInput(result.binaryArgs);
+					} catch (err) {
+						toast(err.message);
+						return;
+					}
 
-					const parsedArgs = parseArgsInput(argsInput);
 					const installer = await promptInstaller(binaryCommand);
 					if (installer === null) return;
+
 					const defaultCheckCommand = buildDefaultCheckCommand(
 						binaryCommand,
 						installer,
 					);
-
 					const checkCommand = await prompt(
 						strings["lsp-check-command-optional"],
 						defaultCheckCommand,
 						"text",
 						{
-							placeholder: defaultCheckCommand || "which my-language-server",
+							placeholder:
+								defaultCheckCommand || "which my-language-server",
 						},
 					);
 					if (checkCommand === null) return;
 
 					transport = {
 						kind: "stdio",
-						command: String(binaryCommand).trim(),
+						command: binaryCommand,
 						args: parsedArgs,
 					};
 					launcher = {
 						bridge: {
 							kind: "axs",
-							command: String(binaryCommand).trim(),
+							command: binaryCommand,
 							args: parsedArgs,
 						},
 						checkCommand: String(checkCommand || "").trim() || undefined,
@@ -440,6 +478,7 @@ export default function lspSettings() {
 			}
 			return;
 		}
+
 
 		if (key.startsWith("server:")) {
 			const id = key.split(":")[1];


### PR DESCRIPTION
## Summary

This PR improves Acode's built-in LSP integration by fixing workspace handling issues and adding several missing LSP features.

No existing issue tracks this happy to split into smaller PRs if that's preferred for review.


<img width="540" height="1170" alt="WhatsApp Image 2026-08-02 at 6 03 36 PM" src="https://github.com/user-attachments/assets/0a01cf89-4b0d-457a-8fa9-421768ffb2e3" />


<img width="540" height="1170" alt="WhatsApp Image 2026-08-02 at 6 03 37 PM" src="https://github.com/user-attachments/assets/78493529-7752-40dc-938f-b3798450db4a" />


<img width="540" height="1170" alt="WhatsApp Image 2026-08-02 at 6 03 38 PM" src="https://github.com/user-attachments/assets/111f3000-c6f4-4a16-83ab-d6b21aa34dec" />


<img width="540" height="1170" alt="WhatsApp Image 2026-08-02 at 6 03 39 PM" src="https://github.com/user-attachments/assets/53814432-e7fc-4f2d-8c66-81165af87029" />


https://github.com/user-attachments/assets/ea5520f2-9d51-46ed-b5a4-479cac98c6ea


## Changes

### LSP actions menu

- Added a dedicated LSP menu instead of directly opening code actions.
- Added access to navigation actions such as:
  - Go to Definition
  - Show References
  - Other LSP commands
- Code actions are automatically executed when only one action is available.

### LSP session management

- Added delayed shutdown when all project files are closed.
- The LSP remains alive for 45 seconds (hardcoded) to handle quick file switching without shutting down the whole session.
- Automatically releases resources when no longer needed.

### Workspace URI handling

- Fixed URI translation between Acode's internal filesystem and LSP paths.
- Added support for:
  - Local storage
  - Termux workspaces
  - SFTP workspaces

This allows LSP features such as navigation and formatting to work across these workspace types.

### Code actions and formatting

- Improved support for applying text edits from formatters and code actions.
- Current implementation focuses on edits affecting the currently opened document.
- Declared missing client capabilities (`workspace.applyEdit`, `workspace.workspaceFolders`, `textDocument.codeAction.resolveSupport`) so servers that check capabilities before acting (e.g. Dart, jdtls) actually attempt these requests instead of silently refusing or falling back to legacy behavior.

## Known Limitations

- Workspace-wide edits (e.g. cross-file rename) aren't applied yet only edits to the currently open document are handled.
- Remote LSP servers must run on the same machine as the project files. For SFTP, either connect to the remote directly, or port-forward to localhost see setup notes below.
- No RAM/PID display for running servers (this would live on the `acode-ls` side, not in this PR).

## Future Work

- Turn custom server setup into a single form dialog instead of filling fields one at a time.
- Expose custom server config editing in the GUI instead of requiring settings.json edits after creation.
- Investigate cross-file rename support in the LSP menu.

## Testing

Tested with:

- Local storage projects
- Termux workspaces
- SFTP-mounted remote projects

Note that FTP has not been implemented.

Tested against:

- phpactor / phpantom (PHP)
- Dart analysis server
- jdtls (Java)

Tested on:

- Samsung Galaxy A34 5G (Dimensity 1080) as client
  - Termux (version 0.118.3)
- ThinkCentre M710q (Debian 13.4 trixie, 8GB RAM, Intel i5-6400T) as home server

-Tailscale was used for remote access for on the following: ssh, ssh-portforwarding, sftp.

Verified:

- Formatting
- Code actions, including jdtls's "Generate Getters and Setters" flow, which required declaring `codeAction` resolve support
- Go to Definition / Go to References
- `workspace/applyEdit` handling
- Session lifecycle: no crash on rapid file close/reopen (previously a race between `acode-ls` process reuse and client re-initialization)
- Correct project-root resolution across local, Termux, and SFTP-mounted folders

## Testing it yourself

### Server Setup

Make sure you have Node and npm installed first  refer to your distro's documentation for how to do that.

To install the server, run this script in the repo directory:

```
./script/patch_acodels.sh
```

It fetches from npm, then applies the patches.

Once installed, start the server with:

```
acode-ls
```

Note: by default the shebang is set to `#!/data/data/com.termux/files/usr/bin/node`, the scripts tries to replace it according to your system config, but you can still later replace it yourself to match wherever Node is installed on your machine.

### Client Setup

Once the server is installed and running, register your custom language server in Acode:

Settings → Language servers → Add custom server

Choose **WebSocket (connect to a wss URL)** as the transport, then fill in the fields using the format:

```
ws://[ip:port]/auto/[server_executable]
```

or, with arguments:

```
ws://[ip:port]/auto/[server_executable]?args=["arg1","arg2"]
```

Example configurations:

| Server ID | Server label | Language IDs | URL |
|---|---|---|---|
| `mypylsp` | PYTHON - pylsp | `python` | `ws://127.0.0.1:3030/auto/pylsp` |
| `jedi` | PYTHON - jedi | `python` | `ws://127.0.0.1:3030/auto/jedi-language-server` |
| `phpactor` | PHP - phpactor | `php` | `ws://127.0.0.1:3030/auto/phpactor?args=["language-server"]` |
| `phpantom` | PHP - phpantom | `php` | `ws://127.0.0.1:3030/auto/phpantom` |
| `jdtls` | JAVA - jdtls | `java` | `ws://100.50.2.4:3030/auto/jdtls?args=["-data","/path/to/jdtls-data"]` |
| `dart` | DART - dart analyzer | `dart` | `ws://127.0.0.1:3030/auto/dart?args=["language-server"]` |



NOTE: You must install the server on your own and make sure that the executable are reachable by PATH, otherwise it may not work.

### Security warning ( edited in )

The WebSocket proxy can start language server processes requested through the URL.

Only expose your chosen port to trusted clients.

Recommended setups:
- localhost
- SSH port forwarding
- private VPN networks such as Tailscale ( as used here for the development )

Do not expose this service directly to the public internet.


### Test the LSP

`acode-ls` must be running first. If your server is configured correctly, you should see it working once you start using Acode. You can add `initializationOptions` from the custom server's settings page as needed.

## Acknowledgements

I would like to thank @7HR4IZ3 for their previous work on the LSP integration and the foundation that made these improvements possible.

I would also like to thank the Acode contributors who worked on bringing built-in LSP support to the editor, as well as everyone involved in creating and maintaining the Language Server Protocol ecosystem.

Acode has been extremely useful to me, especially when I was working without a laptop and relying on a phone + home server setup, so I hope these improvements can help other users as well.
