### PR TITLE
fix(terminal): close tab on process end and speed up long-press select

### DIFF
--- a/src/components/terminal/terminal.js
+++ b/src/components/terminal/terminal.js
@@ -74,6 +74,9 @@ export default class TerminalComponent {
 		this.boundNativeSelectionMenuHandler = null;
 		this.visibleScrollbarWidth = undefined;
 		this.lastRequestedServerSize = null;
+		// Lifecycle flags so exit/disconnect/error don't race into zombie tabs
+		this.intentionalClose = false;
+		this.processExited = false;
 
 		this.init();
 	}
@@ -336,7 +339,7 @@ export default class TerminalComponent {
 				this.container,
 				{
 					tapHoldDuration:
-						terminalSettings.touchSelectionTapHoldDuration || 600,
+						terminalSettings.touchSelectionTapHoldDuration || 400,
 					moveThreshold: terminalSettings.touchSelectionMoveThreshold || 8,
 					handleSize: terminalSettings.touchSelectionHandleSize || 24,
 					hapticFeedback:
@@ -853,19 +856,20 @@ export default class TerminalComponent {
 			};
 
 			websocket.onmessage = (event) => {
-				// Handle text messages (exit events)
-				if (typeof event.data === "string") {
-					try {
-						const message = JSON.parse(event.data);
-						if (message.type === "exit") {
-							this.onProcessExit?.(message.data);
-							return;
-						}
-					} catch (error) {
-						// Not a JSON message, let attachAddon handle it
+				// Handle text (or text-encoded) exit events. AttachAddon still receives
+				// the same frames via addEventListener and writes PTY output.
+				const payload = this.decodeWebSocketPayload(event?.data);
+				if (payload == null) return;
+
+				try {
+					const message = JSON.parse(payload);
+					if (message?.type === "exit") {
+						this.processExited = true;
+						this.onProcessExit?.(message.data);
 					}
+				} catch {
+					// Not a JSON control message — terminal I/O is handled by AttachAddon.
 				}
-				// For binary data or non-exit text messages, let attachAddon handle them
 			};
 
 			websocket.onclose = (event) => {
@@ -881,7 +885,12 @@ export default class TerminalComponent {
 					return;
 				}
 
-				this.onDisconnect?.();
+				this.onDisconnect?.({
+					intentional: this.intentionalClose,
+					processExited: this.processExited,
+					code: event?.code,
+					reason: event?.reason,
+				});
 			};
 
 			websocket.onerror = (error) => {
@@ -893,6 +902,9 @@ export default class TerminalComponent {
 					);
 					return;
 				}
+
+				// Ignore teardown noise from intentional close / already-handled exit
+				if (this.intentionalClose || this.processExited) return;
 
 				console.error("WebSocket error:", error);
 				this.onError?.(error);
@@ -1266,11 +1278,43 @@ export default class TerminalComponent {
 	}
 
 	/**
+	 * Decode a websocket payload to a UTF-8 string when possible.
+	 * Exit control messages may arrive as text or ArrayBuffer depending on
+	 * binaryType / native bridge timing.
+	 * @param {string|ArrayBuffer|ArrayBufferView|null|undefined} data
+	 * @returns {string|null}
+	 */
+	decodeWebSocketPayload(data) {
+		if (typeof data === "string") return data;
+		if (data == null) return null;
+
+		try {
+			if (data instanceof ArrayBuffer) {
+				return new TextDecoder().decode(data);
+			}
+			if (ArrayBuffer.isView(data)) {
+				return new TextDecoder().decode(data);
+			}
+		} catch {
+			return null;
+		}
+
+		return null;
+	}
+
+	/**
 	 * Terminate terminal session
 	 */
 	async terminate() {
+		this.intentionalClose = true;
+
 		if (this.websocket) {
-			this.websocket.close();
+			try {
+				this.websocket.close();
+			} catch {
+				// Already closed
+			}
+			this.websocket = null;
 		}
 
 		if (this.pid && this.serverMode) {
@@ -1296,6 +1340,7 @@ export default class TerminalComponent {
 	 * Dispose terminal
 	 */
 	dispose() {
+		this.intentionalClose = true;
 		this.terminate();
 
 		// Dispose touch selection
@@ -1334,7 +1379,7 @@ export default class TerminalComponent {
 
 	// Event handlers (can be overridden)
 	onConnect() {}
-	onDisconnect() {}
+	onDisconnect(_info) {}
 	onError(error) {}
 	onTitleChange(title) {}
 	onBell() {}

--- a/src/components/terminal/terminal.js
+++ b/src/components/terminal/terminal.js
@@ -856,13 +856,16 @@ export default class TerminalComponent {
 			};
 
 			websocket.onmessage = (event) => {
-				// Handle text (or text-encoded) exit events. AttachAddon still receives
-				// the same frames via addEventListener and writes PTY output.
-				const payload = this.decodeWebSocketPayload(event?.data);
-				if (payload == null) return;
+				// Lifecycle control (AXS exit JSON) is always a text frame.
+				// Never decode binary frames as exit — ordinary PTY output can
+				// contain the same bytes and must not close the session.
+				// AttachAddon still receives frames via addEventListener for I/O.
+				if (typeof event.data !== "string") return;
+				// Cordova websocket may flag binary payloads even when decoded as string
+				if (event.binary === true) return;
 
 				try {
-					const message = JSON.parse(payload);
+					const message = JSON.parse(event.data);
 					if (message?.type === "exit") {
 						this.processExited = true;
 						this.onProcessExit?.(message.data);
@@ -1275,31 +1278,6 @@ export default class TerminalComponent {
 				this.touchSelection.updateCellDimensions();
 			}, 100);
 		}
-	}
-
-	/**
-	 * Decode a websocket payload to a UTF-8 string when possible.
-	 * Exit control messages may arrive as text or ArrayBuffer depending on
-	 * binaryType / native bridge timing.
-	 * @param {string|ArrayBuffer|ArrayBufferView|null|undefined} data
-	 * @returns {string|null}
-	 */
-	decodeWebSocketPayload(data) {
-		if (typeof data === "string") return data;
-		if (data == null) return null;
-
-		try {
-			if (data instanceof ArrayBuffer) {
-				return new TextDecoder().decode(data);
-			}
-			if (ArrayBuffer.isView(data)) {
-				return new TextDecoder().decode(data);
-			}
-		} catch {
-			return null;
-		}
-
-		return null;
 	}
 
 	/**

--- a/src/components/terminal/terminalDefaults.js
+++ b/src/components/terminal/terminalDefaults.js
@@ -19,7 +19,7 @@ export const DEFAULT_TERMINAL_SETTINGS = {
 	failsafeMode: false,
 	prootDebug: false,
 	// Touch selection settings
-	touchSelectionTapHoldDuration: 600,
+	touchSelectionTapHoldDuration: 400,
 	touchSelectionMoveThreshold: 8,
 	touchSelectionHandleSize: 24,
 	touchSelectionHapticFeedback: true,

--- a/src/components/terminal/terminalManager.js
+++ b/src/components/terminal/terminalManager.js
@@ -765,24 +765,64 @@ class TerminalManager {
 			}
 		}, 200);
 
+		// Idempotent end-of-session path. Exit JSON, unexpected disconnect, and
+		// socket errors all funnel here so a missed exit message can't leave a
+		// zombie tab with a dead PTY.
+		let sessionFinished = false;
+		const finishTerminalSession = async ({
+			message = null,
+			showToast = true,
+			errorAlert = null,
+		} = {}) => {
+			if (sessionFinished) return;
+			sessionFinished = true;
+
+			try {
+				terminalComponent.intentionalClose = true;
+				await this.closeTerminal(terminalId, true);
+			} catch (error) {
+				console.error(
+					`Failed to finish terminal session ${terminalId}:`,
+					error,
+				);
+			}
+
+			if (showToast && message) {
+				toast(message);
+			}
+			if (errorAlert) {
+				alert(strings["error"], errorAlert);
+			}
+		};
+
 		// Terminal event handlers
 		terminalComponent.onConnect = () => {
 			console.log(`Terminal ${terminalId} connected`);
 		};
 
-		terminalComponent.onDisconnect = () => {
-			console.log(`Terminal ${terminalId} disconnected`);
+		terminalComponent.onDisconnect = (info = {}) => {
+			console.log(`Terminal ${terminalId} disconnected`, info);
+
+			// User/tab close and dispose intentionally close the socket.
+			if (info.intentional) return;
+
+			// Exit message already drove finishTerminalSession (or is about to).
+			// Still call finish so a race can't leave the tab open; it's idempotent.
+			const message = info.processExited ? null : "Terminal session ended";
+			void finishTerminalSession({
+				message,
+				showToast: !info.processExited,
+			});
 		};
 
 		terminalComponent.onError = (error) => {
 			console.error(`Terminal ${terminalId} error:`, error);
 
-			// Close the terminal and remove the tab
-			this.closeTerminal(terminalId, true);
-
-			// Show alert for connection error
 			const errorMessage = error?.message || "Connection lost";
-			alert(strings["error"], `Terminal connection error: ${errorMessage}`);
+			void finishTerminalSession({
+				showToast: false,
+				errorAlert: `Terminal connection error: ${errorMessage}`,
+			});
 		};
 
 		terminalComponent.onTitleChange = async (title) => {
@@ -811,20 +851,21 @@ class TerminalManager {
 		};
 
 		terminalComponent.onProcessExit = (exitData) => {
-			// Format exit message based on exit code and signal
+			const data = exitData && typeof exitData === "object" ? exitData : {};
 			let message;
-			if (exitData.signal) {
-				message = `Process terminated by signal ${exitData.signal}`;
-			} else if (exitData.exit_code === 0) {
-				message = `Process exited successfully (code ${exitData.exit_code})`;
+			if (data.signal) {
+				message = `Process terminated by signal ${data.signal}`;
+			} else if (data.exit_code === 0 || data.exit_code === "0") {
+				message = `Process exited successfully (code ${data.exit_code})`;
+			} else if (data.exit_code !== undefined && data.exit_code !== null) {
+				message = `Process exited with code ${data.exit_code}`;
+			} else if (typeof exitData === "string" || typeof exitData === "number") {
+				message = `Process exited with code ${exitData}`;
 			} else {
-				message = `Process exited with code ${exitData.exit_code}`;
+				message = "Process exited";
 			}
 
-			this.closeTerminal(terminalId);
-			terminalFile._skipTerminalCloseConfirm = true;
-			terminalFile.remove(true, { ignorePinned: true });
-			toast(message);
+			void finishTerminalSession({ message });
 		};
 
 		// Handle acode CLI open commands (OSC 7777)
@@ -871,18 +912,24 @@ class TerminalManager {
 	/**
 	 * Close a terminal session
 	 * @param {string} terminalId - Terminal ID
+	 * @param {boolean} removeTab - Also remove the editor tab
+	 * @returns {Promise<void>}
 	 */
-	closeTerminal(terminalId, removeTab = false) {
+	async closeTerminal(terminalId, removeTab = false) {
 		const terminal = this.terminals.get(terminalId);
 		if (!terminal) return;
 
 		try {
+			if (terminal.component) {
+				terminal.component.intentionalClose = true;
+			}
+
 			if (terminal.component.serverMode && terminal.component.pid) {
 				this.removePersistedSession(terminal.component.pid);
 			}
 
 			// Cleanup resize observer
-			if (terminal.file._resizeObserver) {
+			if (terminal.file?._resizeObserver) {
 				terminal.file._resizeObserver.disconnect();
 				terminal.file._resizeObserver = null;
 			}
@@ -895,14 +942,14 @@ class TerminalManager {
 			// Dispose terminal component
 			terminal.component.dispose();
 
-			// Remove from map
+			// Remove from map before tab removal so onclose re-entry is a no-op
 			this.terminals.delete(terminalId);
 
 			// Optionally remove the tab as well
 			if (removeTab && terminal.file) {
 				try {
 					terminal.file._skipTerminalCloseConfirm = true;
-					terminal.file.remove(true, { ignorePinned: true });
+					await terminal.file.remove(true, { ignorePinned: true });
 				} catch (removeError) {
 					console.error("Error removing terminal tab:", removeError);
 				}

--- a/src/components/terminal/terminalTouchSelection.js
+++ b/src/components/terminal/terminalTouchSelection.js
@@ -136,7 +136,7 @@ export default class TerminalTouchSelection {
 		this.terminal = terminal;
 		this.container = container;
 		this.options = {
-			tapHoldDuration: 600,
+			tapHoldDuration: 400,
 			moveThreshold: 8,
 			handleSize: 24,
 			hapticFeedback: true,


### PR DESCRIPTION
Close the terminal tab when the PTY exits or the socket drops, not only when the AXS exit JSON arrives, so users no longer get a dead zombie tab after typing exit. Also lower the default touch selection hold from 600ms to 400ms so long-press select feels more responsive.