### PR TITLE
refactor(loader): Extract `tailSpin` SVG component and dynamic gradient logic

### DIFF
--- a/src/components/tailSpin.js
+++ b/src/components/tailSpin.js
@@ -1,0 +1,15 @@
+import tailSpinSvg from "res/tail-spin.svg?raw";
+
+const tailSpinGradientId = "tail-spin-gradient";
+let tailSpinSvgId = 0;
+
+const createTailSpinSvg = () => {
+	const gradientId = `${tailSpinGradientId}-${tailSpinSvgId++}`;
+	return tailSpinSvg.replaceAll(tailSpinGradientId, gradientId);
+};
+
+Object.defineProperty(createTailSpinSvg, "name", {
+	value: "createTailSpinSvg",
+});
+
+export default createTailSpinSvg;

--- a/src/dialogs/loader.js
+++ b/src/dialogs/loader.js
@@ -1,21 +1,14 @@
+import createTailSpinSvg from "components/tailSpin.js";
 import DOMPurify from "dompurify";
 import Ref from "html-tag-js/ref";
 import actionStack from "lib/actionStack";
 import restoreTheme from "lib/restoreTheme";
-import tailSpinSvg from "res/tail-spin.svg?raw";
 
 let loaderIsImmortal = false;
 let onCancelCallback = null;
 let $currentDialog = null;
 let $currentMask = null;
 const titleLoaderId = "__title-loader";
-const tailSpinGradientId = "tail-spin-gradient";
-let tailSpinSvgId = 0;
-
-function createTailSpinSvg() {
-	const gradientId = `${tailSpinGradientId}-${tailSpinSvgId++}`;
-	return tailSpinSvg.split(tailSpinGradientId).join(gradientId);
-}
 
 /**
  * @typedef {object} LoaderOptions


### PR DESCRIPTION
This pull request refactors the `tailSpin` loader logic by extracting the SVG component creation and dynamic gradient ID generation out of `src/dialogs/loader.js` and into a dedicated component file `src/components/tailSpin.js`.

## Motivation & Context
Previously, `src/dialogs/loader.js` directly imported raw SVG assets and maintained local state variables for tracking unique gradient IDs across loader instances. This design violated the Single Responsibility Principle by mixing asset preparation and dynamic string manipulation with high-level dialog lifecycle management. 

By decoupling this logic, we encapsulate SVG generation into a standalone module. This improves code organization, reduces clutter in `loader.js`, and allows `tailSpin` to be cleanly imported and reused elsewhere in the project if needed without duplicating asset configuration or ID incrementation logic.

## Detailed Changes

### `src/components/tailSpin.js` (New Component)
* **Module Encapsulation:** Created a dedicated component module for generating `tailSpin` SVG markup.
* **Asset Handling:** Moved the raw SVG resource import (`res/tail-spin.svg?raw`) into this standalone file.
* **Dynamic Gradient IDs:** Retained module-scoped state (`tailSpinSvgId`) and base key (`tailSpinGradientId`) to ensure every generated SVG instance receives a unique gradient ID (e.g., `tail-spin-gradient-0`, `tail-spin-gradient-1`). This prevents SVG rendering issues caused by duplicate ID collisions in the DOM when multiple spinners are present.
* **String Manipulation Refactor:** Modernized the replacement logic by adopting `String.prototype.replaceAll()`, replacing the older `.split().join()` pattern.
* **Explicit Function Metadata:** Added `Object.defineProperty` to explicitly set the `name` property on `createTailSpinSvg`, ensuring consistent stack tracing and debugging introspection.
* **Default Export:** Exported `createTailSpinSvg` as the module's default export.

### `src/dialogs/loader.js`
* **Cleaned Up Dependencies:** Removed redundant local implementations of `createTailSpinSvg`, raw SVG import statements, and local gradient tracking variables (`tailSpinGradientId`, `tailSpinSvgId`).
* **Import Component:** Updated the loader module to import `createTailSpinSvg` directly from `components/tailSpin.js`.

## Technical Benefits
1. **Separation of Concerns:** Dialog controllers focus purely on dialog state and behavior, delegating asset creation to UI component helpers.
2. **Reusability:** The `tailSpin` SVG creator can now be reused by any other component or dialog in Acode without importing dialog-specific overhead.
3. **Cleaner Syntax:** Replaced legacy string splitting techniques with native `replaceAll` for improved readability and code clarity.

<sub>(PR name and description are AI generated (Gemini 3.6 Flash))</sub>