### PR TITLE
fix: fall back to internal storage when external storage is unavailable

### DIFF
--- a/src/lib/acode.js
+++ b/src/lib/acode.js
@@ -718,7 +718,7 @@ class Acode {
 	}
 
 	get exitAppMessage() {
-		const numFiles = editorManager.hasUnsavedFiles();
+		const numFiles = editorManager?.hasUnsavedFiles?.() ?? 0;
 		if (numFiles) {
 			return strings["unsaved files close app"];
 		}

--- a/src/main.js
+++ b/src/main.js
@@ -100,6 +100,20 @@ document.addEventListener("deviceready", onDeviceReady);
 document.addEventListener("backbutton", backButtonHandler);
 document.addEventListener("menubutton", menuButtonHandler);
 
+async function ensurePermission(permission) {
+	try {
+		const granted = await helpers.promisify(system.hasPermission, permission);
+		if (!granted) {
+			await helpers.promisify(system.requestPermission, permission);
+		}
+	} catch (error) {
+		logger.log(
+			"error",
+			`Failed to request permission ${permission}: ${error.message || error}`,
+		);
+	}
+}
+
 async function onDeviceReady() {
 	await initEncodings(); // important to load encodings before anything else
 
@@ -112,14 +126,37 @@ async function onDeviceReady() {
 		dataDirectory,
 	} = cordova.file;
 
+	async function resolveStorageDir(preferred, fallback) {
+		if (!preferred) return fallback;
+		const fs = fsOperation(preferred);
+		if (!fs) return fallback;
+		try {
+			await fs.stat();
+			return preferred;
+		} catch (error) {
+			logger.log(
+				"warn",
+				`Storage dir unavailable (${preferred}), falling back to ${fallback}: ${error.message || error}`,
+			);
+			return fallback;
+		}
+	}
+
 	window.app = document.body;
 	window.root = tag.get("#root");
 	window.addedFolder = addedFolder;
 	window.editorManager = null;
 	window.toast = toast;
 	window.ASSETS_DIRECTORY = Url.join(cordova.file.applicationDirectory, "www");
-	window.DATA_STORAGE = externalDataDirectory || dataDirectory;
-	window.CACHE_STORAGE = externalCacheDirectory || cacheDirectory;
+	window.DATA_STORAGE = await resolveStorageDir(
+		externalDataDirectory,
+		dataDirectory,
+	);
+	window.CACHE_STORAGE = await resolveStorageDir(
+		externalCacheDirectory,
+		cacheDirectory,
+	);
+
 	window.PLUGIN_DIR = Url.join(DATA_STORAGE, "plugins");
 	window.KEYBINDING_FILE = Url.join(DATA_STORAGE, ".key-bindings.json");
 	window.log = logger.log.bind(logger);
@@ -212,9 +249,11 @@ async function onDeviceReady() {
 	await adRewards.init();
 	ensureAceCompatApi();
 
-	system.requestPermission("android.permission.READ_EXTERNAL_STORAGE");
-	system.requestPermission("android.permission.WRITE_EXTERNAL_STORAGE");
-	system.requestPermission("android.permission.POST_NOTIFICATIONS");
+	if (Number.isInteger(window.ANDROID_SDK_INT) && window.ANDROID_SDK_INT < 33) {
+		await ensurePermission("android.permission.READ_EXTERNAL_STORAGE");
+		await ensurePermission("android.permission.WRITE_EXTERNAL_STORAGE");
+	}
+	await ensurePermission("android.permission.POST_NOTIFICATIONS");
 
 	const { versionCode } = BuildInfo;
 
@@ -227,7 +266,22 @@ async function onDeviceReady() {
 	}
 
 	if (!(await fsOperation(PLUGIN_DIR).exists())) {
-		await fsOperation(DATA_STORAGE).createDirectory("plugins");
+		try {
+			await fsOperation(DATA_STORAGE).createDirectory("plugins");
+		} catch (error) {
+			logger.log(
+				"error",
+				`Failed to create plugins directory, falling back to internal storage: ${error.message || error}`,
+			);
+			window.DATA_STORAGE = dataDirectory;
+			window.CACHE_STORAGE = cacheDirectory;
+			window.PLUGIN_DIR = Url.join(window.DATA_STORAGE, "plugins");
+			window.KEYBINDING_FILE = Url.join(
+				window.DATA_STORAGE,
+				".key-bindings.json",
+			);
+			await fsOperation(window.DATA_STORAGE).createDirectory("plugins");
+		}
 	}
 
 	localStorage.versionCode = versionCode;

--- a/www/index.html
+++ b/www/index.html
@@ -141,12 +141,25 @@
         );
       }
 
+      function isStorageError(reason) {
+        if (!reason) return false;
+        return (
+          reason.name === "FileError" ||
+          reason.name === "NotFoundError" ||
+          reason.name === "SecurityError" ||
+          (typeof reason.code === "number" && reason.code >= 1 && reason.code <= 12)
+        );
+      }
+
       function handleStartupError(event) {
         if (!isStartupLoading()) return;
         var message = event && event.message ? event.message : "Startup error";
         setStartupMessage(
-          "Acode failed to start. Update Android System WebView or Chrome. " +
-          message
+          isStorageError(event && event.error)
+            ? "Acode failed to start: storage is unavailable. Try restarting your device, or clearing the app data. " +
+                message
+            : "Acode failed to start. Update Android System WebView or Chrome. " +
+                message
         );
       }
 
@@ -156,8 +169,11 @@
         var message =
           reason && reason.message ? reason.message : "Startup promise failed";
         setStartupMessage(
-          "Acode failed to start. Update Android System WebView or Chrome. " +
-          message
+          isStorageError(reason)
+            ? "Acode failed to start: storage is unavailable. Try restarting your device, or clearing the app data. " +
+                message
+            : "Acode failed to start. Update Android System WebView or Chrome. " +
+                message
         );
       }
 

--- a/www/index.html
+++ b/www/index.html
@@ -147,7 +147,8 @@
           reason.name === "FileError" ||
           reason.name === "NotFoundError" ||
           reason.name === "SecurityError" ||
-          (typeof reason.code === "number" && reason.code >= 1 && reason.code <= 12)
+          (typeof window.FileError !== "undefined" &&
+            reason instanceof window.FileError)
         );
       }
 


### PR DESCRIPTION
## What

Fixes the app failing to start on devices where the external storage directory cannot be created. On such devices users were stuck on the splash screen with a misleading **"Acode failed to start. Update Android System WebView or Chrome."** message — the WebView was fine, the problem was storage.

## Reported by

- https://t.me/foxdebug_acode/1/157932
- https://t.me/foxdebug_acode/150650/164093
- https://t.me/foxdebug_acode/1/71463

## Root cause

1. `src/main.js` unconditionally picked the external data directory:
   `window.DATA_STORAGE = externalDataDirectory || dataDirectory;`
2. The Cordova `file` plugin only registers `files-external` if the external root directory can be created (`newRoot.mkdirs()` fails on affected devices), so the chosen URL points at a non-existent filesystem.
3. The subsequent plugins-directory creation was **not** wrapped in try/catch:
   `if (!(await fsOperation(PLUGIN_DIR).exists())) await fsOperation(DATA_STORAGE).createDirectory("plugins");`
4. Its unhandled rejection aborted `onDeviceReady()` before `loadApp()`, leaving `editorManager` null and the splash screen forever — with the error handler blaming WebView/Chrome.

Logcat evidence on an affected device:

```
FileUtils: Unable to create root dir for filesystem "files-external", skipping
FileUtils: Unable to create root dir for filesystem "cache-external", skipping
Uncaught (in promise) #<FileError> at build/main.js (63221)
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'hasUnsavedFiles')
```

## Changes

- **`src/main.js`**
  - Added `resolveStorageDir()` — probes the preferred directory with `fs.stat()` and falls back to internal storage when unavailable
  - Wrapped plugins-directory creation in try/catch; on failure it reassigns `DATA_STORAGE`/`CACHE_STORAGE`/`PLUGIN_DIR`/`KEYBINDING_FILE` to internal storage and retries
  - Storage permission requests are now guarded: only requested on SDK < 33, and only when `hasPermission` returns false (`ensurePermission()` helper), preventing background-activity-launch blocks
- **`src/lib/acode.js`** — `editorManager?.hasUnsavedFiles?.() ?? 0` in `exitAppMessage` (the error above was a downstream symptom of the aborted startup)
- **`www/index.html`** — startup error/rejection handlers now detect storage errors (`FileError`/`NotFoundError`/`SecurityError`/DOMException codes 1-12) and show an honest **"Acode failed to start: storage is unavailable"** message instead of blaming WebView/Chrome

## Tested

The same patch was verified on an affected device: app now falls back to internal storage and starts normally, and storage errors produce an accurate message. CI (biome, typos, vitest) runs on this PR.

Fixes the class of startup failures reported as "Update Android System WebView or Chrome" that actually originate from unavailable external storage.