### PR TITLE
refactor(file-browser): Replace plain object directory cache with `Map`

### DIFF
--- a/src/pages/fileBrowser/fileBrowser.js
+++ b/src/pages/fileBrowser/fileBrowser.js
@@ -171,7 +171,7 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 		$selectionMenuToggler.style.display = "none";
 		$pasteToggler.style.display = "none";
 		const progress = {};
-		let cachedDir = {};
+		let cachedDir = new Map();
 		let currentDir = {
 			url: null,
 			name: null,
@@ -255,8 +255,6 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 			}
 
 			if (action === "reload") {
-				const { url } = currentDir;
-				if (url in cachedDir) delete cachedDir[url];
 				reload();
 				return;
 			}
@@ -731,7 +729,7 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 			}
 			recents.removeFile(url);
 			openFolder.removeItem(url);
-			delete cachedDir[url];
+			cachedDir.delete(url);
 		}
 
 		function updateSelectionCount($count) {
@@ -1471,8 +1469,8 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 			let list = [];
 			let error = false;
 
-			if (url in cachedDir) {
-				return cachedDir[url];
+			if (cachedDir.has(url)) {
+				return cachedDir.get(url);
 			} else {
 				if (url === "/") {
 					list = await listAllStorages();
@@ -1807,8 +1805,8 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 			const $oldList = $content.get("#list");
 			if ($oldList) {
 				const { url } = currentDir;
-				if (url && cachedDir[url]) {
-					cachedDir[url].scroll = $oldList.scrollTop;
+				if (url && cachedDir.has(url)) {
+					cachedDir.get(url).scroll = $oldList.scrollTop;
 				}
 				$oldList.remove();
 			}
@@ -1817,13 +1815,13 @@ function FileBrowserInclude(mode, info, doesOpenLast = true) {
 			$list.focus();
 
 			currentDir = dir;
-			cachedDir[dir.url] = dir;
+			cachedDir.set(dir.url, dir);
 			updatePasteToggler();
 		}
 
 		function reload() {
 			const { url, name } = currentDir;
-			delete cachedDir[url];
+			cachedDir.delete(url);
 			navigate(url, name);
 		}
 


### PR DESCRIPTION
Replaces the plain object (`{}`) used for directory caching (`cachedDir`) in `src/pages/fileBrowser/fileBrowser.js` with an ES6 `Map` instance.

## Motivation

- **Key Safety:** Plain objects inherit properties from `Object.prototype`, which can lead to collisions or unexpected behavior if file paths match built-in property names. `Map` provides clean key isolation.

### References
- **MDN Map vs. Object Comparison:** https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map#objects_vs._maps

---

## Summary of Code Changes

- **`src/pages/fileBrowser/fileBrowser.js`**:
  - Initialized `cachedDir` variable using `new Map()`.
  - Replaced `url in cachedDir` with `cachedDir.has(url)`.
  - Replaced `cachedDir[url]` access with `cachedDir.get(url)`.
  - Replaced property assignment `cachedDir[dir.url] = dir` with `cachedDir.set(dir.url, dir)`.
  - Replaced property deletion `delete cachedDir[url]` with native `cachedDir.delete(url)`.

<sub>(PR name and description are AI generated (Gemini 3.6 flash))</sub>