### PR TITLE
chore(community-release-notifier): Change sed parsing - TG release notes

### DIFF
--- a/.github/workflows/community-release-notifier.yml
+++ b/.github/workflows/community-release-notifier.yml
@@ -56,7 +56,7 @@ jobs:
         id: vars
         env:
           INPUT_TAG: ${{ github.event.release.tag_name || inputs.tag_name }}
-          INPUT_URL: ${{ github.event.release.url || inputs.url }}
+          INPUT_URL: ${{ github.event.release.html_url || inputs.url }}
           INPUT_BODY: ${{ github.event.release.body || inputs.body }}
         run: |
           TAG="$INPUT_TAG"
@@ -68,7 +68,12 @@ jobs:
           # Escape problematic characters for MarkdownV2 (very conservative escaping)
           # We escape: _ * [ ] ( ) ~ ` > # + - = | { } . ! \
           BODY_SAFE=$(printf '%s' "$INPUT_BODY" | \
-            sed 's/[_*[\]()~`>#+=|{}.!\\-]/\\&/g')
+            sed -E \
+                -e 's/^[[:space:]]*##[[:space:]]*//' \
+                -e 's/^[[:space:]]*\*[[:space:]]+/- /' \
+                -e 's/\*\*([^*]*)\*\*/\*\1\*/g' \
+                -e 's/\\!/!/g' \
+                -e 's/@([A-Za-z0-9-]+)/＠\1/g')
           TAG_SAFE=$(printf '%s' "$TAG" | sed 's/[_*[\]()~`>#+=|{}.!\\-]/\\&/g')
 
           if [[ "$TAG" == *"-nightly"* ]]; then

--- a/.github/workflows/community-release-notifier.yml
+++ b/.github/workflows/community-release-notifier.yml
@@ -145,7 +145,8 @@ jobs:
             ${{ steps.vars.outputs.announce }}
 
             ${{ steps.vars.outputs.body_safe }}
-          format: markdown
+          # disabled for time being see https://github.com/Acode-Foundation/Acode/pull/2832#discussion_r3887130617
+          #format: markdown
           disable_web_page_preview: true
           # Only needed for topic-enabled supergroups/channels
           message_thread_id: ${{ secrets.TELEGRAM_MESSAGE_THREAD_ID }}


### PR DESCRIPTION
This commit fixes Release notes not being sed escaped properly leading towards Telegram notifier failing for Stable Releases as they were auto-generated by git.